### PR TITLE
Fix delivery and packaging calculations

### DIFF
--- a/src/app/api/admin/[id]/route.ts
+++ b/src/app/api/admin/[id]/route.ts
@@ -2,56 +2,15 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { z } from "zod";
-import { createClient } from "@supabase/supabase-js";
-import { getSessionAndRole } from "@/lib/serverAuth";
 
-const getSupabaseAdmin = () => {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) throw new Error("Missing Supabase environment variables");
-  return createClient(url, key, { auth: { persistSession: false } });
-};
+const legacyRouteDisabled = () =>
+  NextResponse.json(
+    {
+      error:
+        "Ten stary endpoint został wyłączony. Strefami zarządza /api/admin/delivery-zones.",
+    },
+    { status: 410 },
+  );
 
-const PatchSchema = z.object({
-  min_distance_km: z.number().nonnegative().optional(),
-  max_distance_km: z.number().nonnegative().optional(),
-  min_order_value: z.number().nonnegative().optional(),
-  cost: z.number().nonnegative().optional(),
-  free_over: z.number().nonnegative().nullable().optional(),
-  eta_min_minutes: z.number().int().nonnegative().optional(),
-  eta_max_minutes: z.number().int().nonnegative().optional(),
-  cost_fixed: z.number().nonnegative().optional(),
-  cost_per_km: z.number().nonnegative().optional(),
-});
-
-export async function PATCH(_: Request, { params }: { params: { id: string } }) {
-  const { session, role } = await getSessionAndRole();
-  if (!session || (role !== "admin" && role !== "employee"))
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  const body = await _.json();
-  const parsed = PatchSchema.safeParse(body);
-  if (!parsed.success)
-    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
-
-  const { data, error } = await getSupabaseAdmin()
-    .from("delivery_zones")
-    .update(parsed.data)
-    .eq("id", params.id)
-    .select()
-    .single();
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ zone: data });
-}
-
-export async function DELETE(_: Request, { params }: { params: { id: string } }) {
-  const { session, role } = await getSessionAndRole();
-  if (!session || (role !== "admin" && role !== "employee"))
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  const { error } = await getSupabaseAdmin().from("delivery_zones").delete().eq("id", params.id);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ ok: true });
-}
+export const PATCH = legacyRouteDisabled;
+export const DELETE = legacyRouteDisabled;

--- a/src/app/api/admin/delivery-zones/[id]/route.ts
+++ b/src/app/api/admin/delivery-zones/[id]/route.ts
@@ -28,6 +28,7 @@ const Patch = z.object({
   cost_fixed: z.number().nonnegative().optional(),
   cost_per_km: z.number().nonnegative().optional(),
   pricing_type: z.enum(["flat", "per_km"]).optional(),
+  destination_city: z.string().trim().min(1).max(100).nullable().optional(),
   active: z.boolean().optional(),
 });
 
@@ -43,6 +44,14 @@ export async function PATCH(req: Request, { params }: RouteContext) {
   const prepared = Object.fromEntries(
     Object.entries(json).map(([key, value]) => {
       if (key === "pricing_type" || key === "active") return [key, value];
+      if (key === "destination_city") {
+        return [
+          key,
+          value == null || String(value).trim() === ""
+            ? null
+            : String(value).trim(),
+        ];
+      }
       return [
         key,
         value === ""

--- a/src/app/api/admin/delivery-zones/[id]/route.ts
+++ b/src/app/api/admin/delivery-zones/[id]/route.ts
@@ -5,6 +5,10 @@ import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { z } from "zod";
 import { getSessionAndRole } from "@/lib/serverAuth";
+import {
+  type DeliveryZonePricing,
+  validateDeliveryZones,
+} from "@/lib/deliveryPricing";
 
 const getSupabaseAdmin = () => {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -14,37 +18,70 @@ const getSupabaseAdmin = () => {
 };
 
 const Patch = z.object({
-  min_distance_km: z.number().optional(),
-  max_distance_km: z.number().optional(),
-  min_order_value: z.number().optional(),
-  cost: z.number().optional(),
-  free_over: z.number().nullable().optional(),
-  eta_min_minutes: z.number().optional(),
-  eta_max_minutes: z.number().optional(),
-  cost_fixed: z.number().optional(),
-  cost_per_km: z.number().optional(),
+  min_distance_km: z.number().int().nonnegative().optional(),
+  max_distance_km: z.number().int().nonnegative().optional(),
+  min_order_value: z.number().nonnegative().optional(),
+  cost: z.number().nonnegative().optional(),
+  free_over: z.number().nonnegative().nullable().optional(),
+  eta_min_minutes: z.number().int().nonnegative().optional(),
+  eta_max_minutes: z.number().int().nonnegative().optional(),
+  cost_fixed: z.number().nonnegative().optional(),
+  cost_per_km: z.number().nonnegative().optional(),
+  pricing_type: z.enum(["flat", "per_km"]).optional(),
+  active: z.boolean().optional(),
 });
 
-export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: Request, { params }: RouteContext) {
+  const { id } = await params;
   const { session, role } = await getSessionAndRole();
   if (!session || (role !== "admin" && role !== "employee"))
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const json = await req.json();
   const prepared = Object.fromEntries(
-    Object.entries(json).map(([k, v]) => [
-      k,
-      v === "" ? null : v === null ? null : Number.isFinite(Number(v)) ? Number(v) : v,
-    ])
+    Object.entries(json).map(([key, value]) => {
+      if (key === "pricing_type" || key === "active") return [key, value];
+      return [
+        key,
+        value === ""
+          ? null
+          : value === null
+            ? null
+            : Number.isFinite(Number(value))
+              ? Number(value)
+              : value,
+      ];
+    }),
   );
   const parsed = Patch.safeParse(prepared);
   if (!parsed.success)
     return NextResponse.json({ error: "Validation", details: parsed.error.format() }, { status: 400 });
 
-  const { data, error } = await getSupabaseAdmin()
+  const supabase = getSupabaseAdmin();
+  const { data: existing, error: existingError } = await supabase
+    .from("delivery_zones")
+    .select("*");
+  if (existingError) {
+    return NextResponse.json({ error: existingError.message }, { status: 500 });
+  }
+
+  const candidateZones = ((existing ?? []) as DeliveryZonePricing[]).map(
+    (zone) => (zone.id === id ? { ...zone, ...parsed.data } : zone),
+  );
+  const zoneValidationErrors = validateDeliveryZones(candidateZones);
+  if (zoneValidationErrors.length) {
+    return NextResponse.json(
+      { error: zoneValidationErrors.join(" ") },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase
     .from("delivery_zones")
     .update(parsed.data)
-    .eq("id", params.id)
+    .eq("id", id)
     .select()
     .single();
 
@@ -52,12 +89,34 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   return NextResponse.json({ zone: data });
 }
 
-export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+export async function DELETE(_req: Request, { params }: RouteContext) {
+  const { id } = await params;
   const { session, role } = await getSessionAndRole();
   if (!session || (role !== "admin" && role !== "employee"))
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { error } = await getSupabaseAdmin().from("delivery_zones").delete().eq("id", params.id);
+  const supabase = getSupabaseAdmin();
+  const { data: existing, error: existingError } = await supabase
+    .from("delivery_zones")
+    .select("*");
+  if (existingError) {
+    return NextResponse.json({ error: existingError.message }, { status: 500 });
+  }
+
+  const candidateZones = ((existing ?? []) as DeliveryZonePricing[]).filter(
+    (zone) => zone.id !== id,
+  );
+  const zoneValidationErrors = validateDeliveryZones(candidateZones);
+  if (zoneValidationErrors.length) {
+    return NextResponse.json(
+      {
+        error: `Nie można usunąć strefy: ${zoneValidationErrors.join(" ")}`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { error } = await supabase.from("delivery_zones").delete().eq("id", id);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/delivery-zones/route.ts
+++ b/src/app/api/admin/delivery-zones/route.ts
@@ -30,6 +30,7 @@ const Zone = z.object({
   cost_fixed: z.number().nonnegative(),
   cost_per_km: z.number().nonnegative(),
   pricing_type: z.enum(["flat", "per_km"]).default("per_km"),
+  destination_city: z.string().trim().min(1).max(100).nullable().optional(),
   active: z.boolean().default(true),
 }).refine((zone) => zone.max_distance_km >= zone.min_distance_km, {
   message: "Maksymalny kilometr nie może być mniejszy od minimalnego.",
@@ -68,6 +69,11 @@ export async function POST(req: Request) {
     cost_fixed: Number(json.cost_fixed),
     cost_per_km: Number(json.cost_per_km),
     pricing_type: json.pricing_type ?? "per_km",
+    destination_city:
+      json.destination_city == null ||
+      String(json.destination_city).trim() === ""
+        ? null
+        : String(json.destination_city).trim(),
     active: json.active ?? true,
   });
   if (!parsed.success)

--- a/src/app/api/admin/delivery-zones/route.ts
+++ b/src/app/api/admin/delivery-zones/route.ts
@@ -5,6 +5,10 @@ import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { z } from "zod";
 import { getSessionAndRole } from "@/lib/serverAuth";
+import {
+  type DeliveryZonePricing,
+  validateDeliveryZones,
+} from "@/lib/deliveryPricing";
 
 const getSupabaseAdmin = () => {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -16,15 +20,20 @@ const getSupabaseAdmin = () => {
 // Schemat zgodny z formularzem DeliveryZonesForm
 const Zone = z.object({
   id: z.string().uuid().optional(),
-  min_distance_km: z.number(),
-  max_distance_km: z.number(),
-  min_order_value: z.number(),
-  cost: z.number(),
-  free_over: z.number().nullable().optional(),
-  eta_min_minutes: z.number(),
-  eta_max_minutes: z.number(),
-  cost_fixed: z.number(),
-  cost_per_km: z.number(),
+  min_distance_km: z.number().int().nonnegative(),
+  max_distance_km: z.number().int().nonnegative(),
+  min_order_value: z.number().nonnegative(),
+  cost: z.number().nonnegative(),
+  free_over: z.number().nonnegative().nullable().optional(),
+  eta_min_minutes: z.number().int().nonnegative(),
+  eta_max_minutes: z.number().int().nonnegative(),
+  cost_fixed: z.number().nonnegative(),
+  cost_per_km: z.number().nonnegative(),
+  pricing_type: z.enum(["flat", "per_km"]).default("per_km"),
+  active: z.boolean().default(true),
+}).refine((zone) => zone.max_distance_km >= zone.min_distance_km, {
+  message: "Maksymalny kilometr nie może być mniejszy od minimalnego.",
+  path: ["max_distance_km"],
 });
 
 export async function GET() {
@@ -58,11 +67,31 @@ export async function POST(req: Request) {
     eta_max_minutes: Number(json.eta_max_minutes),
     cost_fixed: Number(json.cost_fixed),
     cost_per_km: Number(json.cost_per_km),
+    pricing_type: json.pricing_type ?? "per_km",
+    active: json.active ?? true,
   });
   if (!parsed.success)
     return NextResponse.json({ error: "Validation", details: parsed.error.format() }, { status: 400 });
 
-  const { data, error } = await getSupabaseAdmin()
+  const supabase = getSupabaseAdmin();
+  const { data: existing, error: existingError } = await supabase
+    .from("delivery_zones")
+    .select("*");
+  if (existingError) {
+    return NextResponse.json({ error: existingError.message }, { status: 500 });
+  }
+  const zoneValidationErrors = validateDeliveryZones([
+    ...((existing ?? []) as DeliveryZonePricing[]),
+    parsed.data,
+  ]);
+  if (zoneValidationErrors.length) {
+    return NextResponse.json(
+      { error: zoneValidationErrors.join(" ") },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase
     .from("delivery_zones")
     .insert(parsed.data)
     .select()

--- a/src/app/api/delivery/quote/route.ts
+++ b/src/app/api/delivery/quote/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import {
+  calculateDeliveryQuote,
+  type DeliveryZonePricing,
+  validateDeliveryZones,
+} from "@/lib/deliveryPricing";
+import {
+  getDrivingDistanceKmToPlace,
+  isValidGooglePlaceId,
+} from "@/lib/googleDelivery";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const QuoteRequest = z.object({
+  destination_place_id: z
+    .string()
+    .min(10)
+    .max(255)
+    .refine(isValidGooglePlaceId, "Nieprawidłowy identyfikator adresu."),
+  products_total: z.coerce.number().finite().nonnegative().max(100_000),
+});
+
+const getSupabaseAdmin = () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("Missing Supabase environment variables");
+  return createClient(url, key, { auth: { persistSession: false } });
+};
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const parsed = QuoteRequest.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Wybierz pełny adres z listy Google." },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getSupabaseAdmin();
+  const [{ data: zones, error: zonesError }, { data: restaurant, error: restaurantError }] =
+    await Promise.all([
+      supabase.from("delivery_zones").select("*").eq("active", true),
+      supabase.from("restaurant_info").select("lat,lng").eq("id", 1).single(),
+    ]);
+
+  if (zonesError || restaurantError || !zones || !restaurant) {
+    return NextResponse.json(
+      { error: "Konfiguracja dostawy jest chwilowo niedostępna." },
+      { status: 503 },
+    );
+  }
+
+  const zoneValidationErrors = validateDeliveryZones(
+    zones as DeliveryZonePricing[],
+  );
+  if (zoneValidationErrors.length) {
+    console.error(
+      "[delivery.quote] Invalid delivery zones:",
+      zoneValidationErrors.join(" "),
+    );
+    return NextResponse.json(
+      { error: "Konfiguracja stref dostawy wymaga poprawy." },
+      { status: 503 },
+    );
+  }
+
+  const origin = {
+    lat: Number(restaurant.lat),
+    lng: Number(restaurant.lng),
+  };
+  if (!Number.isFinite(origin.lat) || !Number.isFinite(origin.lng)) {
+    return NextResponse.json(
+      { error: "Punkt startowy restauracji jest nieprawidłowy." },
+      { status: 503 },
+    );
+  }
+
+  let distanceKm: number;
+  try {
+    distanceKm = await getDrivingDistanceKmToPlace(
+      origin,
+      parsed.data.destination_place_id,
+    );
+  } catch (error) {
+    console.error(
+      "[delivery.quote] Google route error:",
+      error instanceof Error ? error.message : error,
+    );
+    return NextResponse.json(
+      { error: "Nie udało się wyznaczyć trasy drogowej. Spróbuj ponownie." },
+      { status: 503 },
+    );
+  }
+
+  const quote = calculateDeliveryQuote(
+    distanceKm,
+    zones as DeliveryZonePricing[],
+    parsed.data.products_total,
+  );
+  if (!quote) {
+    return NextResponse.json(
+      {
+        out_of_range: true,
+        distance_km: Math.round(distanceKm * 100) / 100,
+        billable_distance_km: Math.round(distanceKm),
+        error: "Adres jest poza zasięgiem dostawy.",
+      },
+      { status: 422 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      out_of_range: false,
+      distance_km: quote.distanceKm,
+      billable_distance_km: quote.billableDistanceKm,
+      cost: quote.cost,
+      base_cost: quote.baseCost,
+      min_order_value: quote.minOrderValue,
+      min_order_ok: quote.minOrderOk,
+      eta_min_minutes: quote.etaMinMinutes,
+      eta_max_minutes: quote.etaMaxMinutes,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/src/app/api/delivery/quote/route.ts
+++ b/src/app/api/delivery/quote/route.ts
@@ -7,6 +7,7 @@ import {
   validateDeliveryZones,
 } from "@/lib/deliveryPricing";
 import {
+  getDeliveryPlace,
   getDrivingDistanceKmToPlace,
   isValidGooglePlaceId,
 } from "@/lib/googleDelivery";
@@ -80,11 +81,15 @@ export async function POST(request: Request) {
   }
 
   let distanceKm: number;
+  let deliveryPlace: Awaited<ReturnType<typeof getDeliveryPlace>>;
   try {
-    distanceKm = await getDrivingDistanceKmToPlace(
-      origin,
-      parsed.data.destination_place_id,
-    );
+    [distanceKm, deliveryPlace] = await Promise.all([
+      getDrivingDistanceKmToPlace(
+        origin,
+        parsed.data.destination_place_id,
+      ),
+      getDeliveryPlace(parsed.data.destination_place_id),
+    ]);
   } catch (error) {
     console.error(
       "[delivery.quote] Google route error:",
@@ -100,6 +105,7 @@ export async function POST(request: Request) {
     distanceKm,
     zones as DeliveryZonePricing[],
     parsed.data.products_total,
+    deliveryPlace.city,
   );
   if (!quote) {
     return NextResponse.json(
@@ -124,6 +130,12 @@ export async function POST(request: Request) {
       min_order_ok: quote.minOrderOk,
       eta_min_minutes: quote.etaMinMinutes,
       eta_max_minutes: quote.etaMaxMinutes,
+      pricing_city: quote.zone.destination_city ?? null,
+      pricing_type:
+        String(quote.zone.pricing_type ?? "").toLowerCase() === "flat"
+          ? "flat"
+          : "per_km",
+      cost_per_km: Number(quote.zone.cost_per_km ?? quote.zone.cost ?? 0),
     },
     {
       headers: {

--- a/src/app/api/distance/route.ts
+++ b/src/app/api/distance/route.ts
@@ -1,55 +1,16 @@
-// app/api/distance/route.ts
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
 
-const GOOGLE_KEY = process.env.GOOGLE_MAPS_API_KEY;
-
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const origin = searchParams.get('origin');
-  const destination = searchParams.get('destination');
-
-  if (!origin || !destination) {
-    return NextResponse.json(
-      { error: 'Missing origin or destination' },
-      { status: 400 }
-    );
-  }
-
-  // zbuduj URL dla Distance Matrix
-  const url = `https://maps.googleapis.com/maps/api/distancematrix/json?origins=${encodeURIComponent(
-    origin
-  )}&destinations=${encodeURIComponent(
-    destination
-  )}&key=${GOOGLE_KEY}`;
-
-  // wywołanie
-  const res = await fetch(url);
-  if (!res.ok) {
-    return NextResponse.json(
-      { error: `Google API returned ${res.status}` },
-      { status: 502 }
-    );
-  }
-
-  const data = await res.json();
-
-  if (data.status !== 'OK') {
-    return NextResponse.json(
-      { error: data.error_message || data.status },
-      { status: 500 }
-    );
-  }
-
-  const element = data.rows?.[0]?.elements?.[0];
-  if (!element || element.status !== 'OK') {
-    return NextResponse.json(
-      { error: element?.status || 'No route found' },
-      { status: 500 }
-    );
-  }
-
-  const distance_km = element.distance.value / 1000;
-  const duration_sec = element.duration.value;
-
-  return NextResponse.json({ distance_km, duration_sec });
+/**
+ * Legacy endpoint kept only to make old clients fail explicitly.
+ * Delivery quotes now use /api/delivery/quote, which fixes the origin to the
+ * restaurant and never exposes a general-purpose Google Distance Matrix proxy.
+ */
+export async function GET() {
+  return NextResponse.json(
+    {
+      error:
+        "Ten endpoint został zastąpiony przez bezpieczne wyliczenie kosztu dostawy.",
+    },
+    { status: 410 },
+  );
 }

--- a/src/app/api/dotypos/send-order/route.ts
+++ b/src/app/api/dotypos/send-order/route.ts
@@ -28,6 +28,10 @@ import { createClient } from "@supabase/supabase-js";
 import dotypos, { DotyposOrderItem } from "@/lib/dotypos";
 import { isOnlinePaymentPending } from "@/lib/orderOperations";
 import { DEFAULT_POS_PRODUCT_OVERRIDES } from "@/lib/posProductMappings";
+import {
+  normalizeProductNameForLookup,
+  requiresPackaging,
+} from "@/lib/packaging";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -85,6 +89,7 @@ interface OrderItem {
   price: number;
   addons?: string[];
   note?: string;
+  category?: string | null;
   product_id?: number | string;
   _src?: {
     product_id?: number | string;
@@ -503,6 +508,26 @@ export async function POST(req: NextRequest) {
         addonCategoryMap.set((a.name as string).toLowerCase(), a.category as string);
       }
     }
+
+    // Categories saved on new orders are server-derived. These maps keep
+    // compatibility with older/admin-edited orders that do not contain one.
+    const { data: productCategoriesData, error: productCategoriesError } = await supabase
+      .from("products")
+      .select("id, name, category");
+    const productCategoryById = new Map<string, string>();
+    const productCategoryByName = new Map<string, string>();
+    if (productCategoriesError) {
+      console.warn("[Dotypos Order] Failed to load product categories:", productCategoriesError.message);
+    } else if (productCategoriesData) {
+      for (const product of productCategoriesData) {
+        if (!product.category) continue;
+        productCategoryById.set(String(product.id), product.category);
+        productCategoryByName.set(
+          normalizeProductNameForLookup(product.name),
+          product.category,
+        );
+      }
+    }
     
     // 3.6. Load manual overrides (internal product_id -> pos_id)
     const { data: overridesData, error: overridesError } = await supabase
@@ -542,6 +567,15 @@ export async function POST(req: NextRequest) {
       return undefined;
     };
     const packagingProduct = findSpecialProduct(["pakowanie na wynos", "pakowanie", "opakowanie", "packaging"]);
+    const { data: packagingSettings, error: packagingSettingsError } = await supabase
+      .from("restaurant_info")
+      .select("packaging_cost")
+      .eq("id", 1)
+      .single();
+    const packagingUnitPrice =
+      !packagingSettingsError && Number.isFinite(Number(packagingSettings?.packaging_cost))
+        ? Number(packagingSettings?.packaging_cost)
+        : undefined;
 
     // Smart delivery product selection:
     // - "Dowóz na terenie Ciechanowa" for Ciechanów addresses
@@ -568,7 +602,10 @@ export async function POST(req: NextRequest) {
     const extraSauceProduct = findSpecialProduct(["dodatkowy sos"]);
     const extraFluidCheeseProduct = findSpecialProduct(["dodatkowy płynny ser", "dodatkowy plynny ser"]);
     console.log(`[Dotypos Order] Addon POS products — mięso: ${extraMeatProduct?.pos_id ?? "brak"}, składnik: ${extraIngredientProduct?.pos_id ?? "brak"}, sos: ${extraSauceProduct?.pos_id ?? "brak"}, płynny ser: ${extraFluidCheeseProduct?.pos_id ?? "brak"}`);
-    
+
+    const selectedOpt = order.selected_option || order.order_type || "local";
+    const needsPackaging = selectedOpt === "delivery" || selectedOpt === "takeaway";
+
     // 4. Map order items to Dotypos items
     // Każda sztuka produktu jest osobną pozycją z własnym blokiem dodatków.
     // Dzięki temu kucharz widzi dokładnie które dodatki należą do którego burgera.
@@ -585,6 +622,14 @@ export async function POST(req: NextRequest) {
       const overriddenPosId = internalProductId != null
         ? overrideMap.get(internalProductId)
         : undefined;
+      const itemCategory =
+        item.category ||
+        (rawInternalProductId != null
+          ? productCategoryById.get(String(rawInternalProductId))
+          : undefined) ||
+        productCategoryByName.get(normalizeProductNameForLookup(item.name)) ||
+        "";
+      const itemRequiresPackaging = requiresPackaging(itemCategory);
 
       if (overriddenPosId !== undefined) {
         posProduct = posProducts.find((p) => Number(p.pos_id) === overriddenPosId);
@@ -664,6 +709,18 @@ export async function POST(req: NextRequest) {
           note: itemNote,
         });
         
+        // Opakowanie dla każdej sztuki produktu
+        if (needsPackaging && itemRequiresPackaging && packagingProduct) {
+          dotyposItems.push({
+            id: packagingProduct.pos_id,
+            qty: 1,
+            ...(packagingUnitPrice !== undefined
+              ? { "manual-price": packagingUnitPrice }
+              : {}),
+            note: `Opakowanie do: ${item.name}`,
+          });
+        }
+
         // Dodatkowe mięso dla tej sztuki
         if (extraMeatCount > 0) {
           if (extraMeatProduct) {
@@ -714,18 +771,7 @@ export async function POST(req: NextRequest) {
     }
     
     // 4.5. Add packaging cost as order item
-    const selectedOpt = order.selected_option || order.order_type || "local";
-    const needsPackaging = selectedOpt === "delivery" || selectedOpt === "takeaway";
-    
-    if (needsPackaging && packagingProduct) {
-      dotyposItems.push({
-        id: packagingProduct.pos_id,
-        qty: 1,
-        note: "Opakowanie",
-        // Use POS price (set in Dotypos for the packaging product)
-      });
-      console.log(`[Dotypos Order] Added packaging: POS product "${packagingProduct.name}" (id: ${packagingProduct.pos_id})`);
-    } else if (needsPackaging && !packagingProduct) {
+    if (needsPackaging && !packagingProduct) {
       console.warn('[Dotypos Order] No "Opakowanie" product found in POS. Create it in Dotypos to include packaging cost.');
     }
     

--- a/src/app/api/orders/create/route.ts
+++ b/src/app/api/orders/create/route.ts
@@ -6,6 +6,20 @@ import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { toZonedTime, fromZonedTime } from "date-fns-tz";
 import { dispatchOrderToOperations, isOnlinePaymentPending } from "@/lib/orderOperations";
+import {
+  normalizeProductNameForLookup,
+  requiresPackaging,
+} from "@/lib/packaging";
+import {
+  calculateDeliveryQuote,
+  type DeliveryZonePricing,
+  validateDeliveryZones,
+} from "@/lib/deliveryPricing";
+import {
+  getDeliveryPlace,
+  getDrivingDistanceKmToPlace,
+  isValidGooglePlaceId,
+} from "@/lib/googleDelivery";
 
 /* === email + link śledzenia === */
 import { trackingUrl } from "@/lib/orderLink";
@@ -47,6 +61,7 @@ type NormalizedItem = {
   name: string;
   quantity: number;
   price: number;
+  category?: string | null;
   addons: string[];
   ingredients: string[];
   note?: string;
@@ -251,48 +266,6 @@ function sanitizeOrderStatus(raw: unknown): AllowedOrderStatus {
     ? (value as AllowedOrderStatus)
     : "placed";
 }
-
-/* ===== Haversine ===== */
-const haversineKm = (a:{lat:number;lng:number}, b:{lat:number;lng:number}) => {
-  const R = 6371;
-  const dLat = (b.lat - a.lat) * Math.PI / 180;
-  const dLng = (b.lng - a.lng) * Math.PI / 180;
-  const s1 = Math.sin(dLat/2)**2 +
-             Math.cos(a.lat*Math.PI/180)*Math.cos(b.lat*Math.PI/180)*Math.sin(dLng/2)**2;
-  return 2 * R * Math.asin(Math.sqrt(s1));
-};
-
-// === START INSERT: Google driving distance (optional) ===
-const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY || "";
-
-async function getDrivingDistanceKm(
-  origin: { lat: number; lng: number },
-  dest: { lat: number; lng: number }
-): Promise<number | null> {
-  if (!GOOGLE_MAPS_API_KEY) return null;
-
-  const url =
-    `https://maps.googleapis.com/maps/api/distancematrix/json` +
-    `?origins=${encodeURIComponent(`${origin.lat},${origin.lng}`)}` +
-    `&destinations=${encodeURIComponent(`${dest.lat},${dest.lng}`)}` +
-    `&mode=driving&units=metric&key=${GOOGLE_MAPS_API_KEY}`;
-
-  const res = await fetch(url, { cache: "no-store" });
-  if (!res.ok) return null;
-
-  const data = await res.json().catch(() => null);
-  if (data?.status !== "OK") return null;
-
-  const el = data?.rows?.[0]?.elements?.[0];
-  if (!el || el.status !== "OK") return null;
-
-  const meters = Number(el.distance?.value);
-  if (!Number.isFinite(meters)) return null;
-
-  return meters / 1000;
-}
-// === END INSERT: Google driving distance (optional) ===
-
 
 // === START INSERT: TZ helpers (Europe/Warsaw) ===
 const APP_TZ = "Europe/Warsaw";
@@ -514,6 +487,12 @@ function normalizeBody(raw: any, req: Request) {
     promo_code: pickPromo(base) ?? pickPromo(raw),
     discount_amount: num(base?.discount_amount, 0) ?? 0,
     delivery_cost: num(base?.delivery_cost, null),
+    delivery_place_id:
+      base?.delivery_place_id ??
+      base?.deliveryPlaceId ??
+      raw?.delivery_place_id ??
+      raw?.deliveryPlaceId ??
+      null,
     delivery_lat: num(base?.delivery_lat ?? base?.lat, null),
     delivery_lng: num(base?.delivery_lng ?? base?.lng, null),
     status: sanitizeOrderStatus(base?.status),
@@ -568,24 +547,44 @@ function getAddonPriceFromMap(addonName: string, addonPriceMap: AddonPriceMap): 
 // Mapa kategorii produktów
 type ProductCategoryMap = Map<string, string>;
 
+function resolveProductCategory(it: Any, productCategoryMap: ProductCategoryMap): string {
+  const productId = it.product_id ?? it.productId ?? it.id ?? null;
+  if (productId != null) {
+    const categoryById = productCategoryMap.get(`id:${String(productId)}`);
+    if (categoryById) return categoryById;
+  }
+
+  const normalizedName = normalizeProductNameForLookup(it.name);
+  if (normalizedName) {
+    const categoryByName = productCategoryMap.get(`name:${normalizedName}`);
+    if (categoryByName) return categoryByName;
+  }
+
+  return typeof it.category === "string" ? it.category : "";
+}
+
 function calcSubtotalFromItems(selected_option: string, itemsArray: Any[], packagingCostSetting: number = 2, addonPriceMap: AddonPriceMap = new Map(), productCategoryMap: ProductCategoryMap = new Map()): number {
-  const packaging = (selected_option === "delivery" || selected_option === "takeaway") ? packagingCostSetting : 0;
   const itemsSum = itemsArray.reduce((acc, it) => {
-    const qty = Number(it.quantity ?? 1) || 1;
+    const qty = Number(it.quantity ?? 1);
     const basePrice = money(it.price ?? it.unit_price ?? 0);
     const addons = Array.isArray(it?.options?.addons) ? it.options.addons : (Array.isArray(it.addons) ? it.addons : []);
     const addonsCost = (addons ?? []).reduce((s: number, a: any) => s + getAddonPriceFromMap(String(a), addonPriceMap), 0);
     const extraMeat = Number(it?.options?.extraMeatCount ?? 0) || 0;
     const extraMeatCost = extraMeat * 15;
-    
-    // Kaucja za napoje (oprócz wody)
     const productName = String(it.name || "");
-    const productCategory = productCategoryMap.get(productName.toLowerCase()) || it.category || "";
+    const productCategory = resolveProductCategory(it, productCategoryMap);
+    const packagingCostPerUnit =
+      (selected_option === "delivery" || selected_option === "takeaway") &&
+      requiresPackaging(productCategory)
+        ? packagingCostSetting
+        : 0;
+
+    // Kaucja za napoje (oprócz wody)
     const depositCost = isDrinkWithDeposit(productCategory, productName) ? DEPOSIT_AMOUNT : 0;
     
-    return acc + (basePrice + addonsCost + extraMeatCost + depositCost) * qty;
+    return acc + (basePrice + addonsCost + extraMeatCost + depositCost + packagingCostPerUnit) * qty;
   }, 0);
-  return Math.max(0, Math.round((itemsSum + packaging) * 100) / 100);
+  return Math.max(0, Math.round(itemsSum * 100) / 100);
 }
 
 /* ===================== Handler ===================== */
@@ -619,7 +618,7 @@ export async function POST(req: Request) {
           .eq("available", true),
         supabaseAdmin
           .from("products")
-          .select("name, category"),
+          .select("id, name, category"),
         supabaseAdmin
           .from("order_settings")
           .select("*")
@@ -677,7 +676,11 @@ export async function POST(req: Request) {
       if (!productsErr && products) {
         for (const product of products) {
           if (product.name && product.category) {
-            productCategoryMap.set(product.name.toLowerCase(), product.category);
+            productCategoryMap.set(`id:${String(product.id)}`, product.category);
+            productCategoryMap.set(
+              `name:${normalizeProductNameForLookup(product.name)}`,
+              product.category,
+            );
           }
         }
       }
@@ -966,6 +969,16 @@ if (TURNSTILE_SECRET_KEY) {
     if (!Array.isArray(n.itemsArray) || n.itemsArray.length === 0) {
       return NextResponse.json({ error: "Koszyk jest pusty." }, { status: 400 });
     }
+    const hasInvalidQuantity = n.itemsArray.some((item) => {
+      const quantity = Number(item.quantity ?? 1);
+      return !Number.isSafeInteger(quantity) || quantity < 1 || quantity > 99;
+    });
+    if (hasInvalidQuantity) {
+      return NextResponse.json(
+        { error: "Ilość każdego produktu musi być liczbą całkowitą od 1 do 99." },
+        { status: 400 },
+      );
+    }
 
     // 2.1) Subtotal po stronie serwera
     const baseFromItems = calcSubtotalFromItems(n.selected_option, n.itemsArray, packagingCostSetting, addonPriceMap, productCategoryMap);
@@ -975,7 +988,7 @@ if (TURNSTILE_SECRET_KEY) {
 
     // 2.2) Dostawa
     if (n.selected_option === "delivery") {
-      if (n.delivery_lat == null || n.delivery_lng == null) {
+      if (!isValidGooglePlaceId(n.delivery_place_id)) {
         return NextResponse.json(
           { error: "Wybierz adres z listy, aby ustawić lokalizację dostawy." },
           { status: 400 }
@@ -991,70 +1004,87 @@ if (TURNSTILE_SECRET_KEY) {
         return NextResponse.json({ error: "Brak konfiguracji stref dostawy." }, { status: 500 });
       }
 
-            const originLL = { lat: Number(rest.lat), lng: Number(rest.lng) };
-const destLL = { lat: Number(n.delivery_lat), lng: Number(n.delivery_lng) };
-
-// 1) Google (dystans drogowy) → 2) fallback: Haversine (po prostej)
-const googleKm = await getDrivingDistanceKm(originLL, destLL).catch(() => null);
-const distance_km = googleKm ?? haversineKm(originLL, destLL);
-
-
-
-      const zone = (zones as any[])
-        .sort((a, b) => Number(a.min_distance_km) - Number(b.min_distance_km))
-        .find((z) => distance_km >= Number(z.min_distance_km) && distance_km <= Number(z.max_distance_km));
-
-      if (!zone) {
-        return NextResponse.json({ error: "Adres poza zasięgiem dostawy." }, { status: 400 });
+      const zoneValidationErrors = validateDeliveryZones(
+        zones as DeliveryZonePricing[],
+      );
+      if (zoneValidationErrors.length) {
+        console.error(
+          "[orders.create] Invalid delivery zones:",
+          zoneValidationErrors.join(" "),
+        );
+        return NextResponse.json(
+          { error: "Konfiguracja stref dostawy wymaga poprawy." },
+          { status: 503 },
+        );
       }
 
-      deliveryMinRequired = Number(zone.min_order_value || 0);
+      const origin = { lat: Number(rest.lat), lng: Number(rest.lng) };
+      if (!Number.isFinite(origin.lat) || !Number.isFinite(origin.lng)) {
+        return NextResponse.json(
+          { error: "Punkt startowy restauracji jest nieprawidłowy." },
+          { status: 503 },
+        );
+      }
 
-      // Porównuj z kwotą samych produktów (bez opakowania i dostawy)
+      let distanceKm: number;
+      let deliveryPlace: Awaited<ReturnType<typeof getDeliveryPlace>>;
+      try {
+        [distanceKm, deliveryPlace] = await Promise.all([
+          getDrivingDistanceKmToPlace(origin, n.delivery_place_id),
+          getDeliveryPlace(n.delivery_place_id),
+        ]);
+      } catch (error) {
+        console.error(
+          "[orders.create] Google delivery verification error:",
+          error instanceof Error ? error.message : error,
+        );
+        return NextResponse.json(
+          { error: "Nie udało się potwierdzić drogowej trasy dostawy. Spróbuj ponownie." },
+          { status: 503 },
+        );
+      }
+
       const productsOnlyTotal = calcSubtotalFromItems("local", n.itemsArray, 0, addonPriceMap, productCategoryMap);
-      if (productsOnlyTotal < deliveryMinRequired) {
+      const deliveryQuote = calculateDeliveryQuote(
+        distanceKm,
+        zones as DeliveryZonePricing[],
+        productsOnlyTotal,
+      );
+      if (!deliveryQuote) {
+        return NextResponse.json(
+          {
+            error: `Adres poza zasięgiem dostawy (${Math.round(distanceKm)} km).`,
+          },
+          { status: 400 },
+        );
+      }
+
+      deliveryMinRequired = deliveryQuote.minOrderValue;
+      if (!deliveryQuote.minOrderOk) {
         return NextResponse.json(
           { error: `Minimalna wartość zamówienia dla dostawy to ${deliveryMinRequired.toFixed(2)} zł (wartość produktów: ${productsOnlyTotal.toFixed(2)} zł).` },
           { status: 400 }
         );
       }
 
-            const pricingTypeRaw = String((zone as any).pricing_type ?? "").toLowerCase();
-const pricingType =
-  pricingTypeRaw === "per_km" || pricingTypeRaw === "flat"
-    ? pricingTypeRaw
-    : Number(zone.min_distance_km) === 0
-    ? "flat"
-    : "per_km";
-
-
-      // Twoje realne kolumny: cost (legacy), cost_fixed, cost_per_km
-      const costLegacy = Number((zone as any).cost ?? 0);
-      const costFixed = Number((zone as any).cost_fixed ?? 0);
-      const costPerKm = Number((zone as any).cost_per_km ?? 0);
-
-      let serverCost = 0;
-
-      if (pricingType === "per_km") {
-  const perKmRate = costPerKm > 0 ? costPerKm : costLegacy;
-
-  // mnożymy stawkę za km przez całą odległość
-  serverCost = Math.max(0, costFixed) + Math.max(0, perKmRate) * distance_km;
-} else {
-  // flat
-  serverCost = costFixed > 0 ? costFixed : costLegacy;
-}
-
-
-
-      if (zone.free_over != null && baseFromItems >= Number(zone.free_over)) {
-        serverCost = 0;
-      }
-
-      const rounded = Math.max(0, Math.round(serverCost * 100) / 100);
-
-      n.delivery_cost = rounded;
-      n.total_price = Math.max(0, Math.round((baseFromItems + rounded - Math.min(discount, baseFromItems + rounded)) * 100) / 100);
+      // Dane adresowe i współrzędne pochodzą z Google Place ID, a nie z pól
+      // możliwych do zmiany po stronie klienta.
+      n.street = deliveryPlace.street;
+      n.city = deliveryPlace.city;
+      n.postal_code = deliveryPlace.postalCode;
+      n.address = deliveryPlace.formattedAddress;
+      n.delivery_lat = deliveryPlace.lat;
+      n.delivery_lng = deliveryPlace.lng;
+      n.delivery_cost = deliveryQuote.cost;
+      n.total_price = Math.max(
+        0,
+        Math.round(
+          (baseFromItems +
+            deliveryQuote.cost -
+            Math.min(discount, baseFromItems + deliveryQuote.cost)) *
+            100,
+        ) / 100,
+      );
     } else {
       n.delivery_cost = 0;
       n.total_price = Math.max(0, Math.round((baseFromItems - Math.min(discount, baseFromItems)) * 100) / 100);
@@ -1071,7 +1101,10 @@ const pricingType =
     const normalizedItems: NormalizedItem[] = n.itemsArray.map((it) => {
       const key = String(it.product_id ?? it.productId ?? it.id ?? "");
       const db = productsMap.get(key);
-      return buildItemFromDbAndOptions(db, it);
+      return {
+        ...buildItemFromDbAndOptions(db, it),
+        category: resolveProductCategory(it, productCategoryMap) || null,
+      };
     });
 
     // >>> USTAW MINIMA (przed insertem do orders)

--- a/src/app/api/orders/create/route.ts
+++ b/src/app/api/orders/create/route.ts
@@ -1049,6 +1049,7 @@ if (TURNSTILE_SECRET_KEY) {
         distanceKm,
         zones as DeliveryZonePricing[],
         productsOnlyTotal,
+        deliveryPlace.city,
       );
       if (!deliveryQuote) {
         return NextResponse.json(

--- a/src/components/EditOrderButton.tsx
+++ b/src/components/EditOrderButton.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect } from "react";
 import { createClient } from "@supabase/supabase-js";
+import { countPackagingUnits } from "@/lib/packaging";
 
 const getSupabase = () => {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -20,9 +21,11 @@ const supabase = new Proxy({} as ReturnType<typeof getSupabase>, {
 
 // --- pomocnicze typy ---
 export interface Product {
+  product_id?: string | number;
   name: string;
   price: number;
   quantity: number;
+  category?: string | null;
   meatType?: "wołowina" | "kurczak";
   addons?: string[];
   extraMeatCount?: number;
@@ -39,8 +42,10 @@ interface EditOrderButtonProps {
 }
 
 interface MenuProduct {
+  id: string | number;
   name: string;
   price: number;
+  category: string | null;
   available_addons: string[] | null;
 }
 
@@ -107,12 +112,14 @@ export default function EditOrderButton({
     // Pobierz produkty z bazy
     supabase
       .from("products")
-      .select("name, price, available_addons")
+      .select("id, name, price, category, available_addons")
       .then((r) => {
         if (!r.error && r.data) {
           const parsed = r.data.map((p: any) => ({
+            id: p.id,
             name: p.name || "",
             price: typeof p.price === "number" ? p.price : parseFloat(String(p.price).replace(",", ".")) || 0,
+            category: p.category || null,
             available_addons: Array.isArray(p.available_addons) ? p.available_addons : null,
           }));
           setMenuProducts(parsed);
@@ -156,9 +163,11 @@ export default function EditOrderButton({
           console.warn("Nie znaleziono ceny dla produktu:", item.name);
         }
         return {
+          product_id: item.product_id ?? found?.id,
           name: item.name,
           price: found?.price ?? item.price ?? 0,
           quantity: item.quantity !== undefined ? item.quantity : 1,
+          category: item.category ?? found?.category ?? null,
           extraMeatCount: item.extraMeatCount !== undefined ? item.extraMeatCount : 0,
           addons: item.addons ? [...item.addons] : [],
           meatType: item.meatType || "wołowina",
@@ -231,21 +240,28 @@ export default function EditOrderButton({
     }, 0);
   };
 
+  const getPackagingUnits = () => {
+    if (selectedOption !== "takeaway" && selectedOption !== "delivery") return 0;
+    return countPackagingUnits(products);
+  };
+
   const getPackagingCost = () => {
-    return selectedOption === "takeaway" || selectedOption === "delivery" ? packagingCostSetting : 0;
+    return getPackagingUnits() * packagingCostSetting;
   };
 
   const calculateTotalWithPackaging = () => {
     return calculateBaseTotal() + getPackagingCost();
   };
 
-  const handleAddNewProduct = (productName: string, productPrice: number) => {
+  const handleAddNewProduct = (menuProduct: MenuProduct) => {
     setProducts((prev) => [
       ...prev,
       {
-        name: productName,
-        price: productPrice,
+        product_id: menuProduct.id,
+        name: menuProduct.name,
+        price: menuProduct.price,
         quantity: 1,
+        category: menuProduct.category,
         addons: [],
         extraMeatCount: 0,
         meatType: "wołowina",
@@ -517,12 +533,12 @@ export default function EditOrderButton({
                 <div className="border border-slate-700 bg-slate-900/60 p-4 rounded-lg">
                   <h4 className="font-bold mb-3 text-white">Wybierz produkt</h4>
                   <ul className="space-y-1 max-h-52 overflow-auto">
-                    {MENU_PRODUCTS.map((prod) => (
+                    {menuProducts.map((prod) => (
                       <li key={prod.name}>
                         <button
                           type="button"
                           onClick={() => {
-                            handleAddNewProduct(prod.name, prod.price);
+                            handleAddNewProduct(prod);
                             setShowAddProduct(false);
                           }}
                           className="block w-full text-left px-4 py-2.5 text-slate-300 hover:bg-slate-700 rounded-lg transition-colors"
@@ -550,7 +566,7 @@ export default function EditOrderButton({
                 {(selectedOption === "takeaway" ||
                   selectedOption === "delivery") && (
                   <div className="flex justify-between text-slate-400">
-                    <span>Opakowanie:</span>
+                    <span>Opakowania ({getPackagingUnits()} szt.):</span>
                     <span className="text-slate-300">{getPackagingCost().toFixed(2)} zł</span>
                   </div>
                 )}

--- a/src/components/admin/settings/DeliveryZonesForm.tsx
+++ b/src/components/admin/settings/DeliveryZonesForm.tsx
@@ -17,6 +17,7 @@ type Zone = {
   cost_fixed: number;
   cost_per_km: number;
   pricing_type: "flat" | "per_km";
+  destination_city: string | null;
   active: boolean;
 };
 
@@ -31,6 +32,7 @@ const emptyZone: Omit<Zone, "id"> = {
   cost_fixed: 0,
   cost_per_km: 2,
   pricing_type: "per_km",
+  destination_city: null,
   active: true,
 };
 
@@ -50,7 +52,15 @@ export default function DeliveryZonesForm() {
   const [error, setError] = useState<string | null>(null);
 
   const sorted = useMemo(
-    () => [...zones].sort((a, b) => a.min_distance_km - b.min_distance_km || a.max_distance_km - b.max_distance_km),
+    () => [...zones].sort(
+      (a, b) =>
+        String(a.destination_city ?? "").localeCompare(
+          String(b.destination_city ?? ""),
+          "pl",
+        ) ||
+        a.min_distance_km - b.min_distance_km ||
+        a.max_distance_km - b.max_distance_km,
+    ),
     [zones]
   );
 
@@ -151,7 +161,14 @@ export default function DeliveryZonesForm() {
   }
 
   // Column definitions
-  const columns: { key: keyof Omit<Zone, "id" | "cost" | "pricing_type" | "active">; label: string; w: string; nullable?: boolean }[] = [
+  const columns: {
+    key: keyof Omit<Zone, "id" | "cost" | "pricing_type" | "active">;
+    label: string;
+    w: string;
+    nullable?: boolean;
+    input?: "number" | "text";
+  }[] = [
+    { key: "destination_city", label: "Tylko miasto", w: "w-28", nullable: true, input: "text" },
     { key: "min_distance_km", label: "Min km", w: "w-20" },
     { key: "max_distance_km", label: "Max km", w: "w-20" },
     { key: "min_order_value", label: "Min zam. (zł)", w: "w-24" },
@@ -171,7 +188,8 @@ export default function DeliveryZonesForm() {
       <p className={`text-sm ${t.textMuted}`}>
         Odległość drogowa Google jest zaokrąglana do pełnych kilometrów. Cena
         strefy „za km” to: stała + pełne km × zł/km. Strefy nie mogą się
-        nakładać ani mieć luk.
+        nakładać ani mieć luk w tym samym obszarze. Puste „Tylko miasto”
+        oznacza cennik ogólny; wpisane miasto ma przed nim pierwszeństwo.
       </p>
 
       {/* Error */}
@@ -213,7 +231,18 @@ export default function DeliveryZonesForm() {
               >
                 {columns.map((c) => (
                   <div key={c.key}>
-                    {c.nullable ? (
+                    {c.input === "text" ? (
+                      <input
+                        type="text"
+                        className={t.input}
+                        value={String(z[c.key] ?? "")}
+                        placeholder="— wszystkie"
+                        onChange={(e) => {
+                          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                          editLocal(z.id, c.key, (e.target.value || null) as any);
+                        }}
+                      />
+                    ) : c.nullable ? (
                       <input
                         type="number"
                         className={t.input}
@@ -279,7 +308,20 @@ export default function DeliveryZonesForm() {
           {/* Inputs */}
           {columns.map((c) => (
             <div key={c.key}>
-              {c.nullable ? (
+              {c.input === "text" ? (
+                <input
+                  type="text"
+                  className={t.input}
+                  value={String(draft[c.key] ?? "")}
+                  placeholder="— wszystkie"
+                  onChange={(e) =>
+                    setDraft({
+                      ...draft,
+                      [c.key]: e.target.value || null,
+                    })
+                  }
+                />
+              ) : c.nullable ? (
                 <input
                   type="number"
                   className={t.input}

--- a/src/components/admin/settings/DeliveryZonesForm.tsx
+++ b/src/components/admin/settings/DeliveryZonesForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTheme } from "@/components/admin/ThemeContext";
 import { Plus, Save, Loader2, MapPin, AlertCircle } from "lucide-react";
+import { validateDeliveryZones } from "@/lib/deliveryPricing";
 
 type Zone = {
   id: string;
@@ -15,6 +16,8 @@ type Zone = {
   eta_max_minutes: number;
   cost_fixed: number;
   cost_per_km: number;
+  pricing_type: "flat" | "per_km";
+  active: boolean;
 };
 
 const emptyZone: Omit<Zone, "id"> = {
@@ -26,7 +29,9 @@ const emptyZone: Omit<Zone, "id"> = {
   eta_min_minutes: 30,
   eta_max_minutes: 60,
   cost_fixed: 0,
-  cost_per_km: 0,
+  cost_per_km: 2,
+  pricing_type: "per_km",
+  active: true,
 };
 
 const coerceZones = (j: unknown): Zone[] => {
@@ -82,6 +87,11 @@ export default function DeliveryZonesForm() {
   }, []);
 
   async function create() {
+    const validationErrors = validateDeliveryZones([...zones, draft]);
+    if (validationErrors.length) {
+      setError(validationErrors.join(" "));
+      return;
+    }
     setCreating(true);
     setError(null);
     const r = await fetch("/api/admin/delivery-zones", {
@@ -100,6 +110,14 @@ export default function DeliveryZonesForm() {
   }
 
   async function save(z: Zone) {
+    const candidateZones = zones.map((current) =>
+      current.id === z.id ? z : current,
+    );
+    const validationErrors = validateDeliveryZones(candidateZones);
+    if (validationErrors.length) {
+      setError(validationErrors.join(" "));
+      return;
+    }
     setSavingId(z.id);
     setError(null);
     const { id, ...payload } = z;
@@ -133,7 +151,7 @@ export default function DeliveryZonesForm() {
   }
 
   // Column definitions
-  const columns: { key: keyof Omit<Zone, "id" | "cost">; label: string; w: string; nullable?: boolean }[] = [
+  const columns: { key: keyof Omit<Zone, "id" | "cost" | "pricing_type" | "active">; label: string; w: string; nullable?: boolean }[] = [
     { key: "min_distance_km", label: "Min km", w: "w-20" },
     { key: "max_distance_km", label: "Max km", w: "w-20" },
     { key: "min_order_value", label: "Min zam. (zł)", w: "w-24" },
@@ -150,6 +168,11 @@ export default function DeliveryZonesForm() {
       <div className="flex items-center gap-3">
         <h3 className={`text-lg font-bold ${t.text}`}>Strefy dostawy</h3>
       </div>
+      <p className={`text-sm ${t.textMuted}`}>
+        Odległość drogowa Google jest zaokrąglana do pełnych kilometrów. Cena
+        strefy „za km” to: stała + pełne km × zł/km. Strefy nie mogą się
+        nakładać ani mieć luk.
+      </p>
 
       {/* Error */}
       {error && (
@@ -260,7 +283,7 @@ export default function DeliveryZonesForm() {
                 <input
                   type="number"
                   className={t.input}
-                  value={draft[c.key as keyof typeof draft] ?? ""}
+                  value={(draft[c.key] as number | null) ?? ""}
                   placeholder="—"
                   onChange={(e) => {
                     const raw = e.target.value;

--- a/src/components/menu/AddressAutocomplete.tsx
+++ b/src/components/menu/AddressAutocomplete.tsx
@@ -9,13 +9,19 @@ declare global {
   }
 }
 
-const libraries = ["places"];
+const libraries: ["places"] = ["places"];
 
 type AddressAutocompleteProps = {
-  onAddressSelect: (address: string, lat: number, lng: number) => void;
+  onAddressSelect: (
+    address: string,
+    lat: number,
+    lng: number,
+    placeId: string,
+  ) => void;
   setCity: (value: string) => void;
   setPostalCode: (value: string) => void;
   setFlatNumber?: (value: string) => void;
+  onAddressReset?: () => void;
 };
 
 export default function AddressAutocomplete({
@@ -23,6 +29,7 @@ export default function AddressAutocomplete({
   setCity,
   setPostalCode,
   setFlatNumber,
+  onAddressReset,
 }: AddressAutocompleteProps) {
   const [address, setAddress] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -77,8 +84,13 @@ export default function AddressAutocomplete({
       // wywołujemy callback z CheckoutModal
       const lat = place.geometry?.location.lat();
       const lng = place.geometry?.location.lng();
-      if (typeof lat === "number" && typeof lng === "number") {
-        onAddressSelect(finalStreet, lat, lng);
+      const placeId = place.place_id;
+      if (
+        typeof lat === "number" &&
+        typeof lng === "number" &&
+        typeof placeId === "string"
+      ) {
+        onAddressSelect(finalStreet, lat, lng, placeId);
       }
 
       // uzupełniamy City / PostalCode / FlatNumber
@@ -97,7 +109,10 @@ export default function AddressAutocomplete({
         ref={inputRef}
         type="text"
         value={address}
-        onChange={(e) => setAddress(e.target.value)}
+        onChange={(e) => {
+          setAddress(e.target.value);
+          onAddressReset?.();
+        }}
         placeholder="Wpisz swój adres"
         className="w-full px-3 py-2 border rounded-md"
       />

--- a/src/components/menu/CheckoutModal.tsx
+++ b/src/components/menu/CheckoutModal.tsx
@@ -516,6 +516,8 @@ export default function CheckoutModal() {
     eta: string;
     distanceKm: number;
     billableDistanceKm: number;
+    pricingCity: string | null;
+    costPerKm: number;
   } | null>(null);
 
   // Ustawienia zamówień (włącz/wyłącz typy zamówień)
@@ -872,6 +874,9 @@ export default function CheckoutModal() {
         eta,
         distanceKm: Number(quote.distance_km),
         billableDistanceKm: Number(quote.billable_distance_km),
+        pricingCity:
+          typeof quote.pricing_city === "string" ? quote.pricing_city : null,
+        costPerKm: Number(quote.cost_per_km || 0),
       });
       setErrorMessage(null);
     } catch (error) {
@@ -1504,7 +1509,11 @@ export default function CheckoutModal() {
 
                         {deliveryInfo && (
                           <p className="text-xs text-white/60">
-                            Trasa: {deliveryInfo.billableDistanceKm} km • Koszt dostawy: {deliveryInfo.cost.toFixed(2)} zł • ETA {deliveryInfo.eta}
+                            {deliveryInfo.pricingCity
+                              ? `${deliveryInfo.pricingCity}: opłata stała`
+                              : `Trasa: ${deliveryInfo.billableDistanceKm} km × ${deliveryInfo.costPerKm.toFixed(2)} zł/km`}
+                            {" • "}Koszt dostawy: {deliveryInfo.cost.toFixed(2)} zł
+                            {" • "}ETA {deliveryInfo.eta}
                           </p>
                         )}
                       </div>

--- a/src/components/menu/CheckoutModal.tsx
+++ b/src/components/menu/CheckoutModal.tsx
@@ -13,6 +13,7 @@ import { useSession } from "@supabase/auth-helpers-react";
 import { toZonedTime } from "date-fns-tz";
 import clsx from "clsx";
 import { createPortal } from "react-dom";
+import { countPackagingUnits } from "@/lib/packaging";
 
 declare global {
   interface Window {
@@ -67,21 +68,6 @@ const TERMS_VERSION = process.env.NEXT_PUBLIC_TERMS_VERSION || "2025-09-15";
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || "";
 const THANKS_QR_URL = process.env.NEXT_PUBLIC_REVIEW_QR_URL || "https://g.co/kgs/47NSDMH";
 
-
-type Zone = {
-  id: string;
-  min_distance_km: number;
-  max_distance_km: number;
-  min_order_value: number;
-  cost: number;
-  cost_fixed?: number;
-  cost_per_km?: number;
-  free_over: number | null;
-  eta_min_minutes: number;
-  eta_max_minutes: number;
-  pricing_type?: "per_km" | "flat";
-  active?: boolean;
-};
 
 type Addon = {
   id: string;
@@ -523,11 +509,14 @@ export default function CheckoutModal() {
   const [scheduledTime, setScheduledTime] = useState<string>("10:40");
 
   const [products, setProducts] = useState<Product[]>([]);
-  const [zones, setZones] = useState<Zone[]>([]);
   const [addonsFromDb, setAddonsFromDb] = useState<Addon[]>([]);
-  const [restLoc, setRestLoc] = useState<{ lat: number; lng: number } | null>(null);
   const [packagingCostSetting, setPackagingCostSetting] = useState<number>(2); // domyślnie 2zł, pobierany z bazy
-  const [deliveryInfo, setDeliveryInfo] = useState<{ cost: number; eta: string } | null>(null);
+  const [deliveryInfo, setDeliveryInfo] = useState<{
+    cost: number;
+    eta: string;
+    distanceKm: number;
+    billableDistanceKm: number;
+  } | null>(null);
 
   // Ustawienia zamówień (włącz/wyłącz typy zamówień)
   const [orderSettings, setOrderSettings] = useState<{
@@ -572,6 +561,7 @@ export default function CheckoutModal() {
   const [deliveryMinRequired, setDeliveryMinRequired] = useState(0);
   const [outOfRange, setOutOfRange] = useState(false);
   const [custCoords, setCustCoords] = useState<{ lat: number; lng: number } | null>(null);
+  const [deliveryPlaceId, setDeliveryPlaceId] = useState<string | null>(null);
 
   // email
   const sessionEmail = session?.user?.email || "";
@@ -624,13 +614,6 @@ export default function CheckoutModal() {
         if (!r.error && r.data) setProducts((r.data as Product[]) || []);
       });
 
-    supabase
-      .from("delivery_zones")
-      .select("*")
-      .eq("active", true)
-      .order("min_distance_km", { ascending: true })
-      .then((r) => { if (!r.error && r.data) setZones(r.data as Zone[]); });
-
     // Pobierz dodatki z tabeli addons
     supabase
       .from("addons")
@@ -648,12 +631,11 @@ export default function CheckoutModal() {
 
     supabase
       .from("restaurant_info")
-      .select("lat,lng,packaging_cost")
+      .select("packaging_cost")
       .eq("id", 1)
       .single()
       .then((r) => {
         if (!r.error && r.data) {
-          setRestLoc({ lat: r.data.lat, lng: r.data.lng });
           if (typeof r.data.packaging_cost === "number") {
             setPackagingCostSetting(r.data.packaging_cost);
           }
@@ -840,79 +822,86 @@ export default function CheckoutModal() {
     }, 0);
   }, [items, productByNorm, addonsFromDb, getAddonPrice]);
 
-  const packagingCost = selectedOption === "takeaway" || selectedOption === "delivery" ? packagingCostSetting : 0;
+  const packagingUnits =
+    selectedOption === "takeaway" || selectedOption === "delivery"
+      ? countPackagingUnits(items, (item) => {
+          const meta = productByNorm.get(normalizeName(item.name));
+          return item.category ?? meta?.category;
+        })
+      : 0;
+  const packagingCost = packagingUnits * packagingCostSetting;
   const subtotal = baseTotal + packagingCost;
 
-  const calcDelivery = async (custLat: number, custLng: number) => {
-    if (!restLoc) return;
+  const calcDelivery = async (destinationPlaceId: string) => {
+    setDeliveryInfo(null);
+    setOutOfRange(false);
     try {
-      const resp = await fetch(`/api/distance?origin=${restLoc.lat},${restLoc.lng}&destination=${custLat},${custLng}`);
-      const { distance_km, error } = await resp.json();
-      if (error) { console.error("Distance API:", error); return; }
+      const response = await fetch("/api/delivery/quote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          destination_place_id: destinationPlaceId,
+          products_total: baseTotal,
+        }),
+        cache: "no-store",
+      });
+      const quote = await response.json().catch(() => ({}));
 
-      console.log("[calcDelivery] distance_km:", distance_km, "zones:", zones.map(z => ({
-        min: z.min_distance_km, max: z.max_distance_km, pricing_type: z.pricing_type, 
-        cost: z.cost, cost_fixed: z.cost_fixed, cost_per_km: z.cost_per_km
-      })));
-
-      // Konwersja na number + sortowanie dla pewności (Supabase może zwrócić stringi)
-      const sortedZones = zones
-        .filter(z => z.active !== false)
-        .sort((a, b) => Number(a.min_distance_km) - Number(b.min_distance_km));
-      
-      const zone = sortedZones.find(z => 
-        distance_km >= Number(z.min_distance_km) && distance_km <= Number(z.max_distance_km)
-      );
-
-      console.log("[calcDelivery] selected zone:", zone);
-
-      if (!zone) {
+      if (quote.out_of_range) {
         setOutOfRange(true);
         setDeliveryMinOk(false);
         setDeliveryMinRequired(0);
-        setDeliveryInfo({ cost: 0, eta: "Poza zasięgiem" });
+        setErrorMessage(
+          `Adres jest poza zasięgiem dostawy (${Number(quote.billable_distance_km || 0)} km).`,
+        );
         return;
+      }
+      if (!response.ok) {
+        throw new Error(quote.error || "Nie udało się obliczyć kosztu dostawy.");
       }
 
       setOutOfRange(false);
-
-      // Konwersja wszystkich wartości na number (Supabase może zwrócić stringi)
-      const pricingType = zone.pricing_type ?? (Number(zone.min_distance_km) === 0 ? "flat" : "per_km");
-      const perKm = pricingType === "per_km";
-      
-      let cost: number;
-      if (perKm) {
-        // Mnożymy stawkę za km przez całą odległość
-        const perKmRate = Number(zone.cost_per_km ?? zone.cost ?? 0);
-        const costFixed = Number(zone.cost_fixed ?? 0);
-        cost = costFixed + perKmRate * distance_km;
-        console.log("[calcDelivery] per_km calc:", { perKmRate, costFixed, distance_km, cost });
-      } else {
-        cost = Number(zone.cost_fixed ?? zone.cost ?? 0);
-        console.log("[calcDelivery] flat calc:", { cost });
-      }
-
-      const freeOver = zone.free_over != null ? Number(zone.free_over) : null;
-      if (freeOver != null && subtotal >= freeOver) cost = 0;
-
-      const minOrderValue = Number(zone.min_order_value || 0);
-      // Porównuj z samymi produktami (baseTotal), bez opakowania i dostawy
-      const minOk = baseTotal >= minOrderValue;
+      const minOrderValue = Number(quote.min_order_value || 0);
+      const minOk = Boolean(quote.min_order_ok);
       setDeliveryMinOk(minOk);
       setDeliveryMinRequired(minOrderValue);
 
-      const eta = `${zone.eta_min_minutes}-${zone.eta_max_minutes} min`;
-      console.log("[calcDelivery] final cost:", cost, "eta:", eta);
-      setDeliveryInfo({ cost: Math.max(0, Math.round(cost * 100) / 100), eta });
-    } catch (e) {
-      console.error("calcDelivery error:", e);
+      const eta = `${Number(quote.eta_min_minutes)}-${Number(quote.eta_max_minutes)} min`;
+      setDeliveryInfo({
+        cost: Number(quote.cost),
+        eta,
+        distanceKm: Number(quote.distance_km),
+        billableDistanceKm: Number(quote.billable_distance_km),
+      });
+      setErrorMessage(null);
+    } catch (error) {
+      console.error("calcDelivery error:", error);
+      setDeliveryInfo(null);
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Nie udało się obliczyć kosztu dostawy.",
+      );
     }
   };
 
-  const onAddressSelect = (address: string, lat: number, lng: number) => {
+  const onAddressSelect = (
+    address: string,
+    lat: number,
+    lng: number,
+    placeId: string,
+  ) => {
     setStreet(address);
     setCustCoords({ lat, lng });
-    calcDelivery(lat, lng);
+    setDeliveryPlaceId(placeId);
+    void calcDelivery(placeId);
+  };
+
+  const resetSelectedAddress = () => {
+    setCustCoords(null);
+    setDeliveryPlaceId(null);
+    setDeliveryInfo(null);
+    setOutOfRange(false);
   };
 
   // Re-check min order value reactively when baseTotal changes (e.g. item added/removed after address set)
@@ -1054,6 +1043,7 @@ export default function CheckoutModal() {
       payload.postal_code = postalCode || null;
       payload.city = city || null;
       payload.flat_number = flatNumber || null;
+      payload.delivery_place_id = deliveryPlaceId;
       if (custCoords) {
         payload.delivery_lat = custCoords.lat;
         payload.delivery_lng = custCoords.lng;
@@ -1066,10 +1056,9 @@ export default function CheckoutModal() {
 
   const buildItemsPayload = () =>
     items.map((item: any, index: number) => {
-      // jeżeli w koszyku mamy już id, użyjemy go; w przeciwnym razie dopasujemy po nazwie
-      const meta = item.product_id ? { id: item.product_id } as Product : findMetaByName(item.name);
+      const meta = findMetaByName(item.name);
       const inferred = inferDefaultMeat(meta, item.name);
-            const burger = isBurger(meta, item.name);
+      const burger = isBurger(meta, item.name);
       const fries = isFries(meta, item.name);
 
       const sanitizedAddons: string[] = burger
@@ -1079,10 +1068,11 @@ export default function CheckoutModal() {
           : [];
 
       return {
-        product_id: (meta as any)?.id ?? null,
+        product_id: item.product_id ?? meta?.id ?? null,
         name: item.name,
         quantity: item.quantity || 1,
         unit_price: toPrice(item.price),
+        category: item.category ?? meta?.category ?? null,
         options: {
           meatType: burger ? (item.meatType ?? inferred) : null,
           extraMeatCount: burger ? item.extraMeatCount : 0,
@@ -1200,7 +1190,7 @@ export default function CheckoutModal() {
       if (selectedOption === "delivery") {
         if (outOfRange) throw new Error("Adres jest poza zasięgiem dostawy.");
         if (!deliveryMinOk) throw new Error(`Minimalna wartość zamówienia dla tej strefy to ${deliveryMinRequired.toFixed(2)} zł.`);
-        if (!custCoords) throw new Error("Wybierz adres z listy, aby ustawić lokalizację dostawy.");
+        if (!custCoords || !deliveryPlaceId) throw new Error("Wybierz adres z listy, aby ustawić lokalizację dostawy.");
         if (!deliveryInfo) throw new Error("Poczekaj na przeliczenie kosztu dostawy.");
       }
 
@@ -1235,7 +1225,7 @@ export default function CheckoutModal() {
       if (selectedOption === "delivery") {
         if (outOfRange) throw new Error("Adres jest poza zasięgiem dostawy.");
         if (!deliveryMinOk) throw new Error(`Minimalna wartość zamówienia dla tej strefy to ${deliveryMinRequired.toFixed(2)} zł.`);
-        if (!custCoords) throw new Error("Wybierz adres z listy, aby ustawić lokalizację dostawy.");
+        if (!custCoords || !deliveryPlaceId) throw new Error("Wybierz adres z listy, aby ustawić lokalizację dostawy.");
         if (!deliveryInfo) throw new Error("Poczekaj na przeliczenie kosztu dostawy.");
       }
 
@@ -1305,7 +1295,7 @@ export default function CheckoutModal() {
     !paymentMethod ||
     !legalAccepted ||
     (TURNSTILE_SITE_KEY && !turnstileToken) ||
-    (selectedOption === "delivery" && (!!outOfRange || !deliveryMinOk || !custCoords || !deliveryInfo)) ||
+    (selectedOption === "delivery" && (!!outOfRange || !deliveryMinOk || !custCoords || !deliveryPlaceId || !deliveryInfo)) ||
     submitting;
 
   // === PORTAL ===
@@ -1499,22 +1489,22 @@ export default function CheckoutModal() {
                     <h2 className="text-2xl font-bold text-center text-white">Dane kontaktowe</h2>
                     {selectedOption === "delivery" && (
                       <div className="space-y-3">
-                        <AddressAutocomplete onAddressSelect={onAddressSelect} setCity={setCity} setPostalCode={setPostalCode} setFlatNumber={setFlatNumber} />
+                        <AddressAutocomplete onAddressSelect={onAddressSelect} onAddressReset={resetSelectedAddress} setCity={setCity} setPostalCode={setPostalCode} setFlatNumber={setFlatNumber} />
 
                         {!custCoords ? <p className="text-xs text-red-400">Najpierw wyszukaj i wybierz adres z listy powyżej.</p> : null}
 
                         <div className={clsx("grid grid-cols-1 gap-2", !custCoords && "opacity-50 pointer-events-none")}>
-                          <input type="text" placeholder="Adres" className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:border-yellow-400/50 focus:outline-none" value={street} onChange={(e) => setStreet(e.target.value)} disabled={!custCoords || submitting} />
+                          <input type="text" placeholder="Adres" className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white/80 placeholder-white/40 focus:outline-none" value={street} readOnly disabled={!custCoords || submitting} />
                           <div className="flex gap-2">
                             <input type="text" placeholder="Nr mieszkania" className="flex-1 px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:border-yellow-400/50 focus:outline-none" value={flatNumber} onChange={(e) => setFlatNumber(e.target.value)} disabled={!custCoords || submitting} />
-                            <input type="text" placeholder="Kod pocztowy" className="flex-1 px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:border-yellow-400/50 focus:outline-none" value={postalCode} onChange={(e) => setPostalCode(e.target.value)} disabled={!custCoords || submitting} />
+                            <input type="text" placeholder="Kod pocztowy" className="flex-1 px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white/80 placeholder-white/40 focus:outline-none" value={postalCode} readOnly disabled={!custCoords || submitting} />
                           </div>
-                          <input type="text" placeholder="Miasto" className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/40 focus:border-yellow-400/50 focus:outline-none" value={city} onChange={(e) => setCity(e.target.value)} disabled={!custCoords || submitting} />
+                          <input type="text" placeholder="Miasto" className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white/80 placeholder-white/40 focus:outline-none" value={city} readOnly disabled={!custCoords || submitting} />
                         </div>
 
                         {deliveryInfo && (
                           <p className="text-xs text-white/60">
-                            Koszt dostawy: {deliveryInfo.cost.toFixed(2)} zł • ETA {deliveryInfo.eta}
+                            Trasa: {deliveryInfo.billableDistanceKm} km • Koszt dostawy: {deliveryInfo.cost.toFixed(2)} zł • ETA {deliveryInfo.eta}
                           </p>
                         )}
                       </div>
@@ -1582,7 +1572,7 @@ export default function CheckoutModal() {
 
                         <div className="border-t border-white/10 pt-3 space-y-2">
                           <div className="flex justify-between text-sm"><span className="text-white/60">Produkty:</span><span className="text-white font-medium">{baseTotal.toFixed(2)} zł</span></div>
-                          {(selectedOption === "takeaway" || selectedOption === "delivery") && <div className="flex justify-between text-sm"><span className="text-white/60">Opakowanie:</span><span className="text-white font-medium">{packagingCost.toFixed(2)} zł</span></div>}
+                          {(selectedOption === "takeaway" || selectedOption === "delivery") && <div className="flex justify-between text-sm"><span className="text-white/60">Opakowania ({packagingUnits} szt.):</span><span className="text-white font-medium">{packagingCost.toFixed(2)} zł</span></div>}
                           {deliveryInfo && <div className="flex justify-between text-sm"><span className="text-white/60">Dostawa:</span><span className="text-white font-medium">{deliveryInfo.cost.toFixed(2)} zł</span></div>}
                           {discount > 0 && <div className="flex justify-between text-sm"><span className="text-white/60">Rabat:</span><span className="text-white font-medium">-{discount.toFixed(2)} zł</span></div>}
                         </div>
@@ -1663,9 +1653,9 @@ export default function CheckoutModal() {
                               }
                               setShowConfirmation(true);
                             }}
-                            disabled={!name || !phone || !validEmail || (selectedOption === "delivery" && (!custCoords || !deliveryInfo)) || submitting || (!!TURNSTILE_SITE_KEY && !turnstileToken)}
+                            disabled={!name || !phone || !validEmail || (selectedOption === "delivery" && (!custCoords || !deliveryPlaceId || !deliveryInfo)) || submitting || (!!TURNSTILE_SITE_KEY && !turnstileToken)}
                             aria-busy={submitting}
-                            className="flex-1 py-3 bg-white text-black rounded-xl font-bold disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation inline-flex items-center justify-center gap-2 hover:bg-white/90 transition-all text-sm"
+                            className="flex-1 py-3 bg-white text-black rounded-xl font-bold disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation inline-flex items-center justify-center gap-2 hover:bg-white/90 transition-all"
                           >
                             {submitting ? <Spinner /> : null}
                             {submitting ? "Przetwarzanie…" : `Zamawiam • ${totalWithDelivery.toFixed(2)} zł`}
@@ -1673,7 +1663,7 @@ export default function CheckoutModal() {
                         ) : (
                           <button
                             onClick={paymentMethod === "Online" ? handleOnlinePayment : handleSubmitOrder}
-                            disabled={confirmDisabled || !name || !phone || !validEmail || (selectedOption === "delivery" && (!custCoords || !deliveryInfo))}
+                            disabled={confirmDisabled || !name || !phone || !validEmail || (selectedOption === "delivery" && (!custCoords || !deliveryPlaceId || !deliveryInfo))}
                             aria-busy={submitting}
                             className="flex-1 py-3 bg-green-500 text-white rounded-xl font-bold hover:bg-green-400 touch-manipulation inline-flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed transition text-sm"
                           >
@@ -1790,7 +1780,7 @@ export default function CheckoutModal() {
               <div className="sticky top-4 bg-zinc-900 border border-white/10 rounded-2xl shadow-xl p-5 space-y-3">
                 <h2 className="text-lg font-semibold text-white">Podsumowanie</h2>
                 <div className="flex justify-between text-sm text-white/70"><span>Produkty:</span><span className="text-white">{baseTotal.toFixed(2)} zł</span></div>
-                {(selectedOption === "takeaway" || selectedOption === "delivery") && <div className="flex justify-between text-sm text-white/70"><span>Opakowanie:</span><span className="text-white">{packagingCost.toFixed(2)} zł</span></div>}
+                {(selectedOption === "takeaway" || selectedOption === "delivery") && <div className="flex justify-between text-sm text-white/70"><span>Opakowania ({packagingUnits} szt.):</span><span className="text-white">{packagingCost.toFixed(2)} zł</span></div>}
                 {deliveryInfo && <div className="flex justify-between text-sm text-white/70"><span>Dostawa:</span><span className="text-white">{deliveryInfo.cost.toFixed(2)} zł</span></div>}
 
                 {selectedOption === "delivery" && outOfRange && (

--- a/src/components/menu/MenuSection.tsx
+++ b/src/components/menu/MenuSection.tsx
@@ -14,8 +14,10 @@ export interface RawMenuCategory {
   subcategories?: {
     name: string;
     items: {
+      id?: string | number;
       name: string;
       price: number;
+      category?: string | null;
       description?: string;
       ingredients?: string[];
       imageUrl?: string;
@@ -23,8 +25,10 @@ export interface RawMenuCategory {
     }[];
   }[];
   items?: {
+    id?: string | number;
     name: string;
     price: number;
+    category?: string | null;
     description?: string;
     ingredients?: string[];
     imageUrl?: string;
@@ -86,8 +90,10 @@ function normalizeSupabaseData(data: SupabaseProduct[]): RawMenuCategory[] {
     if (!map[cat]) map[cat] = {};
 
     const itemObj = {
+      id: p.id,
       name: p.name,
       price: money(p.price),
+      category: cat,
       description: p.description || undefined,
       ingredients: parseIngredients(p.ingredients),
       imageUrl: p.image_url || undefined,
@@ -231,11 +237,23 @@ export default function MenuSection() {
     // Pokaż wszystkie produkty ze wszystkich kategorii
     sourceMenu.forEach((cat) => {
       if (cat.items) {
-        products = [...products, ...cat.items];
+        products = [
+          ...products,
+          ...cat.items.map((item) => ({
+            ...item,
+            category: item.category ?? cat.category,
+          })),
+        ];
       }
       if (cat.subcategories) {
         cat.subcategories.forEach((sub) => {
-          products = [...products, ...sub.items];
+          products = [
+            ...products,
+            ...sub.items.map((item) => ({
+              ...item,
+              category: item.category ?? cat.category,
+            })),
+          ];
         });
       }
     });
@@ -244,9 +262,15 @@ export default function MenuSection() {
       const subcat =
         categoryData.subcategories.find((s) => s.name === selectedSubcategory) ||
         categoryData.subcategories[0];
-      products = subcat?.items || [];
+      products = (subcat?.items || []).map((item) => ({
+        ...item,
+        category: item.category ?? categoryData.category,
+      }));
     } else {
-      products = categoryData.items || [];
+      products = (categoryData.items || []).map((item) => ({
+        ...item,
+        category: item.category ?? categoryData.category,
+      }));
     }
   }
 
@@ -436,7 +460,12 @@ function MobileProductCard({ product, isFirst }: { product: any; isFirst: boolea
     : product.description || "";
 
   const handleAdd = () => {
-    addItem({ name: product.name, price: product.price });
+    addItem({
+      product_id: product.id,
+      name: product.name,
+      price: product.price,
+      category: product.category,
+    });
     setAdded(true);
     setTimeout(() => setAdded(false), 1200);
   };

--- a/src/components/menu/ProductCard.tsx
+++ b/src/components/menu/ProductCard.tsx
@@ -5,8 +5,10 @@ import { Plus, Check } from "lucide-react";
 import useCartStore from "@/store/cartStore";
 
 interface Product {
+  id?: string | number;
   name: string;
   price: number;
+  category?: string | null;
   description?: string;
   ingredients?: string[] | string | null;
 }
@@ -54,7 +56,12 @@ export default function ProductCard({ product, index }: ProductCardProps) {
   const isLongText = bodyText.length > 80;
 
   const handleAddToCart = () => {
-    addItem({ name: product.name, price: product.price });
+    addItem({
+      product_id: product.id,
+      name: product.name,
+      price: product.price,
+      category: product.category,
+    });
     setAdded(true);
     setTimeout(() => setAdded(false), 1500);
   };

--- a/src/lib/deliveryPricing.test.ts
+++ b/src/lib/deliveryPricing.test.ts
@@ -36,6 +36,21 @@ const zones: DeliveryZonePricing[] = [
   },
 ];
 
+const ciechanowZone: DeliveryZonePricing = {
+  destination_city: "Ciechanów",
+  min_distance_km: 0,
+  max_distance_km: 22,
+  min_order_value: 38,
+  cost: 5,
+  cost_fixed: 5,
+  cost_per_km: 0,
+  free_over: 120,
+  eta_min_minutes: 60,
+  eta_max_minutes: 90,
+  pricing_type: "flat",
+  active: true,
+};
+
 test("rounds Google road distance to the nearest whole billable kilometre", () => {
   assert.equal(toBillableDistanceKm(3.01), 3);
   assert.equal(toBillableDistanceKm(5.5), 6);
@@ -84,6 +99,27 @@ test("reads the rate and fixed amount from the selected database zone", () => {
   );
 });
 
+test("uses the fixed database override for addresses inside Ciechanów", () => {
+  const configuredZones = [...zones, ciechanowZone];
+
+  assert.equal(
+    calculateDeliveryQuote(0.23, configuredZones, 50, "Ciechanów")?.cost,
+    5,
+  );
+  assert.equal(
+    calculateDeliveryQuote(6.8, configuredZones, 50, "ciechanow")?.cost,
+    5,
+  );
+  assert.equal(
+    calculateDeliveryQuote(6.8, configuredZones, 50, "Chruszczewo")?.cost,
+    14,
+  );
+  assert.equal(
+    calculateDeliveryQuote(6.8, configuredZones, 120, "Ciechanów")?.cost,
+    0,
+  );
+});
+
 test("rejects an address beyond the configured 22 km range", () => {
   assert.equal(calculateDeliveryQuote(22.5, zones, 100), null);
 });
@@ -94,7 +130,7 @@ test("checks minimum order against products only", () => {
 });
 
 test("detects overlapping zones and gaps", () => {
-  assert.deepEqual(validateDeliveryZones(zones), []);
+  assert.deepEqual(validateDeliveryZones([...zones, ciechanowZone]), []);
   assert.ok(validateDeliveryZones([]).some((message) => message.includes("Brak")));
   assert.ok(
     validateDeliveryZones([{ ...zones[0], min_distance_km: 1 }]).some(
@@ -112,5 +148,12 @@ test("detects overlapping zones and gaps", () => {
       zones[0],
       { ...zones[1], min_distance_km: 9 },
     ]).some((message) => message.includes("luka")),
+  );
+  assert.ok(
+    validateDeliveryZones([
+      ...zones,
+      ciechanowZone,
+      { ...ciechanowZone, min_distance_km: 10 },
+    ]).some((message) => message.includes("nakładają")),
   );
 });

--- a/src/lib/deliveryPricing.test.ts
+++ b/src/lib/deliveryPricing.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  calculateDeliveryQuote,
+  toBillableDistanceKm,
+  validateDeliveryZones,
+  type DeliveryZonePricing,
+} from "./deliveryPricing";
+
+const zones: DeliveryZonePricing[] = [
+  {
+    min_distance_km: 0,
+    max_distance_km: 7,
+    min_order_value: 38,
+    cost: 2,
+    cost_fixed: 0,
+    cost_per_km: 2,
+    free_over: null,
+    eta_min_minutes: 60,
+    eta_max_minutes: 90,
+    pricing_type: "per_km",
+    active: true,
+  },
+  {
+    min_distance_km: 8,
+    max_distance_km: 22,
+    min_order_value: 38,
+    cost: 2,
+    cost_fixed: 0,
+    cost_per_km: 2,
+    free_over: null,
+    eta_min_minutes: 90,
+    eta_max_minutes: 120,
+    pricing_type: "per_km",
+    active: true,
+  },
+];
+
+test("rounds Google road distance to the nearest whole billable kilometre", () => {
+  assert.equal(toBillableDistanceKm(3.01), 3);
+  assert.equal(toBillableDistanceKm(5.5), 6);
+  assert.equal(toBillableDistanceKm(13.99), 14);
+  assert.equal(toBillableDistanceKm(21.49), 21);
+  assert.equal(toBillableDistanceKm(21.5), 22);
+});
+
+test("matches the supplied price list at 2 zł per whole kilometre", () => {
+  for (const [distanceKm, expectedCost] of [
+    [3, 6],
+    [4, 8],
+    [5, 10],
+    [6, 12],
+    [7, 14],
+    [8, 16],
+    [13, 26],
+    [14, 28],
+    [15, 30],
+    [17, 34],
+    [19, 38],
+    [21, 42],
+    [22, 44],
+  ] as const) {
+    assert.equal(
+      calculateDeliveryQuote(distanceKm, zones, 100)?.cost,
+      expectedCost,
+      `${distanceKm} km`,
+    );
+  }
+});
+
+test("reads the rate and fixed amount from the selected database zone", () => {
+  const configurableZone: DeliveryZonePricing = {
+    min_distance_km: 0,
+    max_distance_km: 20,
+    cost_fixed: 4,
+    cost_per_km: 3,
+    pricing_type: "per_km",
+    active: true,
+  };
+
+  assert.equal(
+    calculateDeliveryQuote(6.2, [configurableZone], 100)?.cost,
+    22,
+  );
+});
+
+test("rejects an address beyond the configured 22 km range", () => {
+  assert.equal(calculateDeliveryQuote(22.5, zones, 100), null);
+});
+
+test("checks minimum order against products only", () => {
+  assert.equal(calculateDeliveryQuote(6, zones, 37.99)?.minOrderOk, false);
+  assert.equal(calculateDeliveryQuote(6, zones, 38)?.minOrderOk, true);
+});
+
+test("detects overlapping zones and gaps", () => {
+  assert.deepEqual(validateDeliveryZones(zones), []);
+  assert.ok(validateDeliveryZones([]).some((message) => message.includes("Brak")));
+  assert.ok(
+    validateDeliveryZones([{ ...zones[0], min_distance_km: 1 }]).some(
+      (message) => message.includes("0 km"),
+    ),
+  );
+  assert.ok(
+    validateDeliveryZones([
+      { ...zones[0], max_distance_km: 8 },
+      zones[1],
+    ]).some((message) => message.includes("nakładają")),
+  );
+  assert.ok(
+    validateDeliveryZones([
+      zones[0],
+      { ...zones[1], min_distance_km: 9 },
+    ]).some((message) => message.includes("luka")),
+  );
+});

--- a/src/lib/deliveryPricing.ts
+++ b/src/lib/deliveryPricing.ts
@@ -1,0 +1,155 @@
+export type DeliveryZonePricing = {
+  id?: string;
+  min_distance_km: number | string;
+  max_distance_km: number | string;
+  min_order_value?: number | string | null;
+  cost?: number | string | null;
+  cost_fixed?: number | string | null;
+  cost_per_km?: number | string | null;
+  free_over?: number | string | null;
+  eta_min_minutes?: number | string | null;
+  eta_max_minutes?: number | string | null;
+  pricing_type?: "flat" | "per_km" | string | null;
+  active?: boolean | null;
+};
+
+export type DeliveryQuote = {
+  distanceKm: number;
+  billableDistanceKm: number;
+  cost: number;
+  baseCost: number;
+  minOrderValue: number;
+  minOrderOk: boolean;
+  etaMinMinutes: number;
+  etaMaxMinutes: number;
+  zone: DeliveryZonePricing;
+};
+
+const asNonNegativeNumber = (value: unknown, fallback = 0): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+const roundMoney = (value: number): number =>
+  Math.round((value + Number.EPSILON) * 100) / 100;
+
+/**
+ * The restaurant price list uses whole road kilometres (e.g. 7 km = 14 zł).
+ * Google returns metres, so the displayed road distance is rounded to the
+ * nearest whole kilometre before selecting a zone and calculating the price.
+ */
+export function toBillableDistanceKm(distanceKm: number): number {
+  if (!Number.isFinite(distanceKm) || distanceKm < 0) {
+    throw new Error("Invalid delivery distance");
+  }
+  return Math.round(distanceKm);
+}
+
+export function findDeliveryZone(
+  zones: readonly DeliveryZonePricing[],
+  billableDistanceKm: number,
+): DeliveryZonePricing | null {
+  const sorted = zones
+    .filter((zone) => zone.active !== false)
+    .slice()
+    .sort(
+      (a, b) =>
+        asNonNegativeNumber(a.min_distance_km) -
+          asNonNegativeNumber(b.min_distance_km) ||
+        asNonNegativeNumber(a.max_distance_km) -
+          asNonNegativeNumber(b.max_distance_km),
+    );
+
+  return (
+    sorted.find((zone) => {
+      const min = asNonNegativeNumber(zone.min_distance_km);
+      const max = asNonNegativeNumber(zone.max_distance_km);
+      return billableDistanceKm >= min && billableDistanceKm <= max;
+    }) ?? null
+  );
+}
+
+export function calculateDeliveryQuote(
+  distanceKm: number,
+  zones: readonly DeliveryZonePricing[],
+  productsTotal: number,
+): DeliveryQuote | null {
+  const billableDistanceKm = toBillableDistanceKm(distanceKm);
+  const zone = findDeliveryZone(zones, billableDistanceKm);
+  if (!zone) return null;
+
+  const pricingType =
+    String(zone.pricing_type ?? "").toLowerCase() === "flat"
+      ? "flat"
+      : "per_km";
+  const legacyCost = asNonNegativeNumber(zone.cost);
+  const fixedCost = asNonNegativeNumber(zone.cost_fixed);
+  const perKmRate = asNonNegativeNumber(zone.cost_per_km, legacyCost);
+
+  const baseCost =
+    pricingType === "flat"
+      ? fixedCost > 0
+        ? fixedCost
+        : legacyCost
+      : fixedCost + perKmRate * billableDistanceKm;
+
+  const freeOver =
+    zone.free_over == null ? null : asNonNegativeNumber(zone.free_over);
+  const safeProductsTotal = asNonNegativeNumber(productsTotal);
+  const cost =
+    freeOver != null && safeProductsTotal >= freeOver ? 0 : baseCost;
+  const minOrderValue = asNonNegativeNumber(zone.min_order_value);
+
+  return {
+    distanceKm: roundMoney(distanceKm),
+    billableDistanceKm,
+    cost: roundMoney(Math.max(0, cost)),
+    baseCost: roundMoney(Math.max(0, baseCost)),
+    minOrderValue,
+    minOrderOk: safeProductsTotal >= minOrderValue,
+    etaMinMinutes: asNonNegativeNumber(zone.eta_min_minutes),
+    etaMaxMinutes: asNonNegativeNumber(zone.eta_max_minutes),
+    zone,
+  };
+}
+
+export function validateDeliveryZones(
+  zones: readonly DeliveryZonePricing[],
+): string[] {
+  const active = zones
+    .filter((zone) => zone.active !== false)
+    .slice()
+    .sort(
+      (a, b) =>
+        asNonNegativeNumber(a.min_distance_km) -
+        asNonNegativeNumber(b.min_distance_km),
+    );
+  const errors: string[] = [];
+
+  if (active.length === 0) {
+    return ["Brak aktywnej strefy dostawy."];
+  }
+
+  if (asNonNegativeNumber(active[0].min_distance_km) !== 0) {
+    errors.push("Pierwsza aktywna strefa musi zaczynać się od 0 km.");
+  }
+
+  for (let index = 0; index < active.length; index += 1) {
+    const zone = active[index];
+    const min = asNonNegativeNumber(zone.min_distance_km);
+    const max = asNonNegativeNumber(zone.max_distance_km);
+    if (max < min) {
+      errors.push(`Strefa ${index + 1}: maksymalny kilometr jest mniejszy od minimalnego.`);
+    }
+    if (index > 0) {
+      const previousMax = asNonNegativeNumber(active[index - 1].max_distance_km);
+      if (min <= previousMax) {
+        errors.push(`Strefy ${index} i ${index + 1} nakładają się.`);
+      } else if (min !== previousMax + 1) {
+        errors.push(`Między strefami ${index} i ${index + 1} jest luka.`);
+      }
+    }
+  }
+
+  return errors;
+}

--- a/src/lib/deliveryPricing.ts
+++ b/src/lib/deliveryPricing.ts
@@ -10,6 +10,7 @@ export type DeliveryZonePricing = {
   eta_min_minutes?: number | string | null;
   eta_max_minutes?: number | string | null;
   pricing_type?: "flat" | "per_km" | string | null;
+  destination_city?: string | null;
   active?: boolean | null;
 };
 
@@ -33,6 +34,22 @@ const asNonNegativeNumber = (value: unknown, fallback = 0): number => {
 const roundMoney = (value: number): number =>
   Math.round((value + Number.EPSILON) * 100) / 100;
 
+const normalizeCity = (value: unknown): string =>
+  String(value ?? "")
+    .trim()
+    .toLocaleLowerCase("pl-PL")
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "");
+
+const isDistanceInZone = (
+  zone: DeliveryZonePricing,
+  billableDistanceKm: number,
+): boolean => {
+  const min = asNonNegativeNumber(zone.min_distance_km);
+  const max = asNonNegativeNumber(zone.max_distance_km);
+  return billableDistanceKm >= min && billableDistanceKm <= max;
+};
+
 /**
  * The restaurant price list uses whole road kilometres (e.g. 7 km = 14 zł).
  * Google returns metres, so the displayed road distance is rounded to the
@@ -48,6 +65,7 @@ export function toBillableDistanceKm(distanceKm: number): number {
 export function findDeliveryZone(
   zones: readonly DeliveryZonePricing[],
   billableDistanceKm: number,
+  destinationCity?: string | null,
 ): DeliveryZonePricing | null {
   const sorted = zones
     .filter((zone) => zone.active !== false)
@@ -60,12 +78,22 @@ export function findDeliveryZone(
           asNonNegativeNumber(b.max_distance_km),
     );
 
+  const requestedCity = normalizeCity(destinationCity);
+  if (requestedCity) {
+    const cityOverride = sorted.find(
+      (zone) =>
+        normalizeCity(zone.destination_city) === requestedCity &&
+        isDistanceInZone(zone, billableDistanceKm),
+    );
+    if (cityOverride) return cityOverride;
+  }
+
   return (
-    sorted.find((zone) => {
-      const min = asNonNegativeNumber(zone.min_distance_km);
-      const max = asNonNegativeNumber(zone.max_distance_km);
-      return billableDistanceKm >= min && billableDistanceKm <= max;
-    }) ?? null
+    sorted.find(
+      (zone) =>
+        !normalizeCity(zone.destination_city) &&
+        isDistanceInZone(zone, billableDistanceKm),
+    ) ?? null
   );
 }
 
@@ -73,9 +101,14 @@ export function calculateDeliveryQuote(
   distanceKm: number,
   zones: readonly DeliveryZonePricing[],
   productsTotal: number,
+  destinationCity?: string | null,
 ): DeliveryQuote | null {
   const billableDistanceKm = toBillableDistanceKm(distanceKm);
-  const zone = findDeliveryZone(zones, billableDistanceKm);
+  const zone = findDeliveryZone(
+    zones,
+    billableDistanceKm,
+    destinationCity,
+  );
   if (!zone) return null;
 
   const pricingType =
@@ -118,35 +151,57 @@ export function validateDeliveryZones(
 ): string[] {
   const active = zones
     .filter((zone) => zone.active !== false)
-    .slice()
-    .sort(
-      (a, b) =>
-        asNonNegativeNumber(a.min_distance_km) -
-        asNonNegativeNumber(b.min_distance_km),
-    );
+    .slice();
   const errors: string[] = [];
 
   if (active.length === 0) {
     return ["Brak aktywnej strefy dostawy."];
   }
 
-  if (asNonNegativeNumber(active[0].min_distance_km) !== 0) {
-    errors.push("Pierwsza aktywna strefa musi zaczynać się od 0 km.");
+  const groups = new Map<string, DeliveryZonePricing[]>();
+  for (const zone of active) {
+    const scope = normalizeCity(zone.destination_city);
+    groups.set(scope, [...(groups.get(scope) ?? []), zone]);
   }
 
-  for (let index = 0; index < active.length; index += 1) {
-    const zone = active[index];
-    const min = asNonNegativeNumber(zone.min_distance_km);
-    const max = asNonNegativeNumber(zone.max_distance_km);
-    if (max < min) {
-      errors.push(`Strefa ${index + 1}: maksymalny kilometr jest mniejszy od minimalnego.`);
+  for (const [scope, scopedZones] of groups) {
+    const sorted = scopedZones.sort(
+      (a, b) =>
+        asNonNegativeNumber(a.min_distance_km) -
+        asNonNegativeNumber(b.min_distance_km),
+    );
+    const scopeLabel = scope
+      ? ` dla miasta „${String(sorted[0].destination_city).trim()}”`
+      : "";
+
+    if (asNonNegativeNumber(sorted[0].min_distance_km) !== 0) {
+      errors.push(
+        `Pierwsza aktywna strefa${scopeLabel} musi zaczynać się od 0 km.`,
+      );
     }
-    if (index > 0) {
-      const previousMax = asNonNegativeNumber(active[index - 1].max_distance_km);
-      if (min <= previousMax) {
-        errors.push(`Strefy ${index} i ${index + 1} nakładają się.`);
-      } else if (min !== previousMax + 1) {
-        errors.push(`Między strefami ${index} i ${index + 1} jest luka.`);
+
+    for (let index = 0; index < sorted.length; index += 1) {
+      const zone = sorted[index];
+      const min = asNonNegativeNumber(zone.min_distance_km);
+      const max = asNonNegativeNumber(zone.max_distance_km);
+      if (max < min) {
+        errors.push(
+          `Strefa ${index + 1}${scopeLabel}: maksymalny kilometr jest mniejszy od minimalnego.`,
+        );
+      }
+      if (index > 0) {
+        const previousMax = asNonNegativeNumber(
+          sorted[index - 1].max_distance_km,
+        );
+        if (min <= previousMax) {
+          errors.push(
+            `Strefy ${index} i ${index + 1}${scopeLabel} nakładają się.`,
+          );
+        } else if (min !== previousMax + 1) {
+          errors.push(
+            `Między strefami ${index} i ${index + 1}${scopeLabel} jest luka.`,
+          );
+        }
       }
     }
   }

--- a/src/lib/googleDelivery.ts
+++ b/src/lib/googleDelivery.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY || "";
+const GOOGLE_TIMEOUT_MS = 8_000;
+
+export type DeliveryPlace = {
+  placeId: string;
+  formattedAddress: string;
+  street: string;
+  city: string;
+  postalCode: string;
+  lat: number;
+  lng: number;
+};
+
+const fetchGoogleJson = async (url: URL): Promise<any> => {
+  if (!GOOGLE_MAPS_API_KEY) {
+    throw new Error("Google Maps API key is not configured");
+  }
+
+  url.searchParams.set("key", GOOGLE_MAPS_API_KEY);
+  const response = await fetch(url, {
+    cache: "no-store",
+    signal: AbortSignal.timeout(GOOGLE_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`Google Maps returned HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  if (payload?.status !== "OK") {
+    throw new Error(payload?.error_message || payload?.status || "Google Maps error");
+  }
+  return payload;
+};
+
+export function isValidGooglePlaceId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 10 &&
+    value.length <= 255 &&
+    /^[A-Za-z0-9_-]+$/.test(value)
+  );
+}
+
+export async function getDrivingDistanceKmToPlace(
+  origin: { lat: number; lng: number },
+  destinationPlaceId: string,
+): Promise<number> {
+  if (
+    !Number.isFinite(origin.lat) ||
+    !Number.isFinite(origin.lng) ||
+    !isValidGooglePlaceId(destinationPlaceId)
+  ) {
+    throw new Error("Invalid delivery route input");
+  }
+
+  const url = new URL("https://maps.googleapis.com/maps/api/distancematrix/json");
+  url.searchParams.set("origins", `${origin.lat},${origin.lng}`);
+  url.searchParams.set("destinations", `place_id:${destinationPlaceId}`);
+  url.searchParams.set("mode", "driving");
+  url.searchParams.set("units", "metric");
+  url.searchParams.set("language", "pl");
+
+  const payload = await fetchGoogleJson(url);
+  const element = payload?.rows?.[0]?.elements?.[0];
+  if (!element || element.status !== "OK") {
+    throw new Error(element?.status || "No driving route found");
+  }
+
+  const meters = Number(element.distance?.value);
+  if (!Number.isFinite(meters) || meters < 0) {
+    throw new Error("Google Maps returned invalid distance");
+  }
+  return meters / 1000;
+}
+
+export async function getDeliveryPlace(
+  destinationPlaceId: string,
+): Promise<DeliveryPlace> {
+  if (!isValidGooglePlaceId(destinationPlaceId)) {
+    throw new Error("Invalid Google place ID");
+  }
+
+  const url = new URL("https://maps.googleapis.com/maps/api/geocode/json");
+  url.searchParams.set("place_id", destinationPlaceId);
+  url.searchParams.set("language", "pl");
+  const payload = await fetchGoogleJson(url);
+  const result = payload?.results?.[0];
+  const location = result?.geometry?.location;
+  if (
+    !result ||
+    !Number.isFinite(Number(location?.lat)) ||
+    !Number.isFinite(Number(location?.lng))
+  ) {
+    throw new Error("Google Maps returned invalid address");
+  }
+
+  const components = Array.isArray(result.address_components)
+    ? result.address_components
+    : [];
+  const component = (type: string) =>
+    components.find((item: any) => item?.types?.includes(type))?.long_name || "";
+  const route = component("route");
+  const streetNumber = component("street_number");
+
+  return {
+    placeId: destinationPlaceId,
+    formattedAddress: String(result.formatted_address || ""),
+    street: [route, streetNumber].filter(Boolean).join(" ") || String(result.formatted_address || ""),
+    city:
+      component("locality") ||
+      component("postal_town") ||
+      component("administrative_area_level_3"),
+    postalCode: component("postal_code"),
+    lat: Number(location.lat),
+    lng: Number(location.lng),
+  };
+}

--- a/src/lib/packaging.test.ts
+++ b/src/lib/packaging.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  countPackagingUnits,
+  packagingQuantity,
+  requiresPackaging,
+} from "./packaging";
+
+test("qualifies food categories and rejects drinks or unknown categories", () => {
+  for (const category of ["Burger", "Pancake", "Frytki", "Kids"]) {
+    assert.equal(requiresPackaging(category), true, category);
+  }
+
+  for (const category of ["Napoje", "Napój", "", null, "Inne"]) {
+    assert.equal(requiresPackaging(category), false, String(category));
+  }
+});
+
+test("counts one packaging unit per food item quantity", () => {
+  assert.equal(
+    countPackagingUnits([
+      { category: "Burger", quantity: 2 },
+      { category: "Pancake", quantity: 1 },
+      { category: "Frytki", quantity: 1 },
+    ]),
+    4,
+  );
+});
+
+test("does not count drinks in a mixed order", () => {
+  assert.equal(
+    countPackagingUnits([
+      { category: "Burger", quantity: 2 },
+      { category: "Napoje", quantity: 3 },
+      { category: "Pancake", quantity: 1 },
+      { category: "Frytki", quantity: 1 },
+    ]),
+    4,
+  );
+});
+
+test("rejects invalid quantities instead of creating fractional or negative units", () => {
+  for (const quantity of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(packagingQuantity(quantity), 0, String(quantity));
+  }
+
+  assert.equal(packagingQuantity(undefined), 1);
+  assert.equal(packagingQuantity(2), 2);
+});

--- a/src/lib/packaging.ts
+++ b/src/lib/packaging.ts
@@ -1,0 +1,48 @@
+export type PackagingItem = {
+  quantity?: unknown;
+  category?: unknown;
+};
+
+const PACKAGED_FOOD_CATEGORIES = new Set([
+  "burger",
+  "frytki",
+  "kids",
+  "pancake",
+]);
+
+export function normalizeProductCategory(category: unknown): string {
+  return String(category ?? "")
+    .trim()
+    .toLocaleLowerCase("pl-PL");
+}
+
+export function normalizeProductNameForLookup(name: unknown): string {
+  return String(name ?? "")
+    .trim()
+    .toLocaleLowerCase("pl-PL")
+    .replace(/ł/g, "l")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function requiresPackaging(category: unknown): boolean {
+  return PACKAGED_FOOD_CATEGORIES.has(normalizeProductCategory(category));
+}
+
+export function packagingQuantity(quantity: unknown): number {
+  const parsed = Number(quantity ?? 1);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+export function countPackagingUnits<T extends PackagingItem>(
+  items: readonly T[],
+  getCategory: (item: T) => unknown = (item) => item.category,
+): number {
+  return items.reduce((total, item) => {
+    if (!requiresPackaging(getCategory(item))) return total;
+    return total + packagingQuantity(item.quantity);
+  }, 0);
+}

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -6,6 +6,7 @@ export interface CartItem {
   name: string;
   price: number;
   quantity?: number;
+  category?: string | null;
 
   // Nowe pola
   meatType?: "wołowina" | "kurczak";

--- a/supabase/migrations/20260729_align_delivery_pricing_with_distance.sql
+++ b/supabase/migrations/20260729_align_delivery_pricing_with_distance.sql
@@ -1,0 +1,137 @@
+-- Cennik dostaw SISI:
+-- drogowy dystans Google zaokrąglony do pełnego kilometra × 2,00 zł/km.
+-- Zakres rozpiski: 0-22 km. Minimalna wartość zamówienia, ETA i próg darmowej
+-- dostawy pozostają takie, jakie są zapisane w bazie.
+--
+-- Migracja celowo NIE używa UUID rekordów. Jest atomowa i zabezpieczona:
+-- aktualizuje wyłącznie rozpoznaną starą konfigurację, a przy innym stanie
+-- przerywa transakcję bez częściowych zmian.
+
+BEGIN;
+
+LOCK TABLE public.delivery_zones IN SHARE ROW EXCLUSIVE MODE;
+
+DO $migration$
+DECLARE
+  active_zone_count integer;
+  target_near_count integer;
+  target_far_count integer;
+  near_zone_id uuid;
+  far_zone_id uuid;
+BEGIN
+  SELECT count(*)
+  INTO active_zone_count
+  FROM public.delivery_zones
+  WHERE active IS TRUE;
+
+  -- Pozwala bezpiecznie ponowić skrypt, jeżeli docelowa konfiguracja już jest.
+  SELECT count(*)
+  INTO target_near_count
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND pricing_type = 'per_km'
+    AND cost = 2
+    AND cost_fixed = 0
+    AND cost_per_km = 2
+    AND min_distance_km = 0
+    AND max_distance_km = 7;
+
+  SELECT count(*)
+  INTO target_far_count
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND pricing_type = 'per_km'
+    AND cost = 2
+    AND cost_fixed = 0
+    AND cost_per_km = 2
+    AND min_distance_km = 8
+    AND max_distance_km = 22;
+
+  IF active_zone_count = 2
+    AND target_near_count = 1
+    AND target_far_count = 1
+  THEN
+    RETURN;
+  END IF;
+
+  -- Oczekiwany stan sprzed zmiany. Jeżeli ktoś wcześniej zmienił cennik,
+  -- migracja ma się zatrzymać zamiast nadpisać nieznaną konfigurację.
+  SELECT id
+  INTO near_zone_id
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND min_distance_km = 0
+    AND max_distance_km = 7
+    AND pricing_type = 'flat'
+    AND cost = 5
+    AND cost_fixed = 5
+    AND cost_per_km = 0
+    AND free_over = 120;
+
+  SELECT id
+  INTO far_zone_id
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND min_distance_km = 7
+    AND max_distance_km = 17
+    AND pricing_type = 'per_km'
+    AND cost = 2
+    AND cost_fixed = 0
+    AND cost_per_km = 2
+    AND free_over IS NULL;
+
+  IF active_zone_count <> 2 OR near_zone_id IS NULL OR far_zone_id IS NULL THEN
+    RAISE EXCEPTION
+      'Przerwano zmianę cennika: aktualne strefy dostawy nie odpowiadają oczekiwanej starej konfiguracji.';
+  END IF;
+
+  UPDATE public.delivery_zones
+  SET
+    min_distance_km = 0,
+    max_distance_km = 7,
+    cost = 2,
+    cost_fixed = 0,
+    cost_per_km = 2,
+    pricing_type = 'per_km'
+  WHERE id = near_zone_id;
+
+  UPDATE public.delivery_zones
+  SET
+    min_distance_km = 8,
+    max_distance_km = 22,
+    cost = 2,
+    cost_fixed = 0,
+    cost_per_km = 2,
+    pricing_type = 'per_km'
+  WHERE id = far_zone_id;
+
+  SELECT count(*)
+  INTO target_near_count
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND pricing_type = 'per_km'
+    AND cost = 2
+    AND cost_fixed = 0
+    AND cost_per_km = 2
+    AND min_distance_km = 0
+    AND max_distance_km = 7;
+
+  SELECT count(*)
+  INTO target_far_count
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND pricing_type = 'per_km'
+    AND cost = 2
+    AND cost_fixed = 0
+    AND cost_per_km = 2
+    AND min_distance_km = 8
+    AND max_distance_km = 22;
+
+  IF target_near_count <> 1 OR target_far_count <> 1 THEN
+    RAISE EXCEPTION
+      'Nie udało się potwierdzić docelowej konfiguracji stref dostawy.';
+  END IF;
+END
+$migration$;
+
+COMMIT;

--- a/supabase/migrations/20260730_add_ciechanow_delivery_override.sql
+++ b/supabase/migrations/20260730_add_ciechanow_delivery_override.sql
@@ -1,0 +1,135 @@
+-- Ciechanów zachowuje dotychczasową stałą opłatę 5 zł.
+-- Pozostałe miejscowości korzystają z ogólnych stref kilometrowych.
+--
+-- WAŻNE: tę migrację należy wykonać dopiero po wdrożeniu kodu obsługującego
+-- destination_city. Stary kod nie rozróżnia zakresów miejskich i ogólnych.
+--
+-- Migracja jest atomowa i nie opiera się na UUID rekordów. Zachowuje z
+-- istniejącej strefy lokalnej minimalną wartość zamówienia, próg darmowej
+-- dostawy oraz ETA.
+
+BEGIN;
+
+LOCK TABLE public.delivery_zones IN SHARE ROW EXCLUSIVE MODE;
+
+ALTER TABLE public.delivery_zones
+  ADD COLUMN IF NOT EXISTS destination_city text;
+
+DO $migration$
+DECLARE
+  generic_near_count integer;
+  generic_far_count integer;
+  city_override_count integer;
+BEGIN
+  SELECT count(*)
+  INTO city_override_count
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND lower(btrim(destination_city)) = lower('Ciechanów');
+
+  -- Bezpieczne ponowienie: zaakceptuj wyłącznie dokładnie oczekiwany rekord.
+  IF city_override_count = 1 AND EXISTS (
+    SELECT 1
+    FROM public.delivery_zones
+    WHERE active IS TRUE
+      AND lower(btrim(destination_city)) = lower('Ciechanów')
+      AND min_distance_km = 0
+      AND max_distance_km = 22
+      AND pricing_type = 'flat'
+      AND cost = 5
+      AND cost_fixed = 5
+      AND cost_per_km = 0
+  ) THEN
+    RETURN;
+  END IF;
+
+  IF city_override_count <> 0 THEN
+    RAISE EXCEPTION
+      'Przerwano migrację: istnieje nieoczekiwana strefa miejska dla Ciechanowa.';
+  END IF;
+
+  SELECT count(*)
+  INTO generic_near_count
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND destination_city IS NULL
+    AND min_distance_km = 0
+    AND max_distance_km = 7
+    AND pricing_type = 'per_km'
+    AND cost = 2
+    AND cost_fixed = 0
+    AND cost_per_km = 2;
+
+  SELECT count(*)
+  INTO generic_far_count
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND destination_city IS NULL
+    AND min_distance_km = 8
+    AND max_distance_km = 22
+    AND pricing_type = 'per_km'
+    AND cost = 2
+    AND cost_fixed = 0
+    AND cost_per_km = 2;
+
+  IF generic_near_count <> 1 OR generic_far_count <> 1 THEN
+    RAISE EXCEPTION
+      'Przerwano migrację: ogólne strefy kilometrowe mają nieoczekiwaną konfigurację.';
+  END IF;
+
+  INSERT INTO public.delivery_zones (
+    min_distance_km,
+    max_distance_km,
+    min_order_value,
+    cost,
+    free_over,
+    eta_min_minutes,
+    eta_max_minutes,
+    cost_fixed,
+    cost_per_km,
+    pricing_type,
+    active,
+    destination_city
+  )
+  SELECT
+    0,
+    22,
+    min_order_value,
+    5,
+    free_over,
+    eta_min_minutes,
+    eta_max_minutes,
+    5,
+    0,
+    'flat',
+    TRUE,
+    'Ciechanów'
+  FROM public.delivery_zones
+  WHERE active IS TRUE
+    AND destination_city IS NULL
+    AND min_distance_km = 0
+    AND max_distance_km = 7
+    AND pricing_type = 'per_km'
+    AND cost = 2
+    AND cost_fixed = 0
+    AND cost_per_km = 2;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.delivery_zones
+    WHERE active IS TRUE
+      AND lower(btrim(destination_city)) = lower('Ciechanów')
+      AND min_distance_km = 0
+      AND max_distance_km = 22
+      AND pricing_type = 'flat'
+      AND cost = 5
+      AND cost_fixed = 5
+      AND cost_per_km = 0
+  ) THEN
+    RAISE EXCEPTION
+      'Nie udało się potwierdzić miejskiej strefy dostawy dla Ciechanowa.';
+  END IF;
+END
+$migration$;
+
+COMMIT;


### PR DESCRIPTION
## Co zmieniono

- naliczanie jednego opakowania za każdą sztukę jedzenia przy dostawie i na wynos, bez naliczania opakowań dla napojów
- wspólny serwerowy kalkulator dostawy oparty na drogowej odległości Google, zaokrąglanej najpierw do pełnych kilometrów
- osobną, konfigurowalną strefę miejską: Ciechanów zachowuje stałą opłatę 5 zł i dotychczasowy próg darmowej dostawy
- ogólne strefy kilometrowe dla miejscowości poza Ciechanowem: 2 zł × pełne kilometry, do 22 km
- ponowne wyliczanie adresu, miasta, kilometrów i kosztu po stronie serwera na podstawie Google Place ID
- walidację luk i nakładania stref osobno dla cennika ogólnego i każdego miasta
- panel administracyjny z polem „Tylko miasto”
- zabezpieczone, atomowe migracje bez UUID rekordów
- wyłączenie starych endpointów pozwalających ominąć bezpieczną wycenę

## Przyczyna

Pierwsza migracja została wykonana przed scaleniem nowego kodu. Produkcja nadal używa starego kalkulatora, który mnoży surową, ułamkową odległość Google przez 2 zł. Dlatego np. 0,23 km dawało 0,46 zł. Dodatkowo sama strefa odległościowa nie potrafi odróżnić Ciechanowa od pobliskiej wsi w podobnej odległości.

## Docelowe działanie

- adres z miastem Google `Ciechanów` → miejska strefa z bazy → stałe 5 zł
- inna miejscowość → drogowy dystans Google → zaokrąglenie do pełnego kilometra → pełne km × stawka z bazy
- przykład: 7,34 km → 7 km → 14 zł
- przykład: 16,97 km → 17 km → 34 zł
- od 22,5 km → 23 km → poza zasięgiem

## Weryfikacja

- testy opakowań — 4/4
- testy dostawy, w tym Ciechanów i miejscowość pozamiejska — 7/7
- rzeczywisty Google Geocoding: adres miejski → `Ciechanów`, Chruszczewo → `Chruszczewo`
- kontrola typów zmienionych plików — OK
- `npm run build` — OK
- `git diff --check` — OK

## Kolejność wdrożenia

Migracja `20260729_align_delivery_pricing_with_distance.sql` została już wykonana w produkcyjnej bazie.

1. Najpierw wdrożyć ten PR na produkcję.
2. Po potwierdzeniu nowego deploymentu uruchomić `supabase/migrations/20260730_add_ciechanow_delivery_override.sql`.
3. Sprawdzić jeden adres w Ciechanowie i jeden poza miastem.
4. Włączyć dostawy ponownie, jeżeli były wyłączone.

Migracji `20260730...` nie wolno uruchamiać przed nowym kodem, ponieważ stary kalkulator nie rozróżnia stref miejskich od ogólnych.